### PR TITLE
Update docs for new appeals state for modmail conversation.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,6 +15,8 @@ Documentation Contributors
 - Eric Woolard `@ericwoolard <https://github.com/ericwoolard>`_
 - Marc `@PerhapsSomeone <https://github.com/PerhapsSomeone>`_
 - Richard Hoekstra `@RichardHoekstra <https://github.com/RichardHoekstra>`_
+- Pim Tholhuijsen `@mandjevant <https://github.com/mandjevant>`_
+
 <!-- - Add "Name <email (optional)> and github profile link" above this line. -->
 
 

--- a/asyncpraw/models/reddit/subreddit.py
+++ b/asyncpraw/models/reddit/subreddit.py
@@ -2359,8 +2359,8 @@ class SubredditModerationStream:
         :param sort: Can be one of: mod, recent, unread, user
             (default: recent).
         :param state: Can be one of: all, archived, highlighted, inprogress,
-            mod, new, notifications, (default: all). "all" does not include
-            internal or archived conversations.
+            mod, new, notifications, or appeals, (default: all). "all" does not
+            include internal, archived, or appeals conversations.
 
         Keyword arguments are passed to :func:`.stream_generator`.
 
@@ -2934,8 +2934,8 @@ class Modmail:
         :param other_subreddits: A list of :class:`.Subreddit` instances for
             which to mark conversations (default: None).
         :param state: Can be one of: all, archived, highlighted, inprogress,
-            mod, new, notifications, (default: all). "all" does not include
-            internal or archived conversations.
+            mod, new, notifications, or appeals, (default: all). "all" does not
+            include internal, archived, or appeals conversations.
         :returns: A list of lazy :class:`.ModmailConversation` instances that were
             marked read.
 
@@ -2973,8 +2973,8 @@ class Modmail:
         :param sort: Can be one of: mod, recent, unread, user
             (default: recent).
         :param state: Can be one of: all, archived, highlighted, inprogress,
-            mod, new, notifications, (default: all). "all" does not include
-            internal or archived conversations.
+            mod, new, notifications, or appeals, (default: all). "all" does not
+            include internal, archived, or appeals conversations.
 
 
         For example:
@@ -3065,7 +3065,7 @@ class Modmail:
         """Return unread conversation count by conversation state.
 
         At time of writing, possible states are: archived, highlighted,
-        inprogress, mod, new, notifications.
+        inprogress, mod, new, notifications, or appeals.
 
         :returns: A dict mapping conversation states to unread counts.
 


### PR DESCRIPTION
## Feature Summary and Justification

This feature provides updated documentation that adds the newly added appeals state to modmail conversations.

## References

* https://www.reddit.com/dev/api/#GET_api_mod_conversations
