### PR TITLE
Possible fix for #11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ Unreleased
 * Ability to submit image galleries with :meth:`.submit_gallery`.
 * Ability to specify modmail mute duration.
 
+**Fixed**
+
+* A bug where if you call `.parent()` on a comment it clears its replies.
+
 7.1.0 (2020/07/16)
 ------------------
 

--- a/asyncpraw/models/reddit/comment.py
+++ b/asyncpraw/models/reddit/comment.py
@@ -278,8 +278,12 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
         """
         # pylint: disable=no-member
 
-        await self._fetch()
-        await self.submission._fetch()
+        if not self._fetched:
+            await self._fetch()
+
+        if not self.submission._fetched:
+            await self.submission._fetch()
+
         if self.parent_id == self.submission.fullname:
             return self.submission
 


### PR DESCRIPTION
Fixes #11

## Feature Summary and Justification

This adds a check to see if the comment and comment's submission is already fetched. When fetching a comment, its replies get cleared. 

## References

* 
*
