### PR TITLE
Change stream cache eviction to least-recently-used

### DIFF
--- a/asyncpraw/models/util.py
+++ b/asyncpraw/models/util.py
@@ -1,6 +1,7 @@
 """Provide helper classes used by other models."""
 import random
 import asyncio
+from collections import OrderedDict
 from typing import Any, Callable, AsyncGenerator, List, Optional, Set
 
 
@@ -13,19 +14,23 @@ class BoundedSet:
     def __init__(self, max_items: int):
         """Construct an instance of the BoundedSet."""
         self.max_items = max_items
-        self._fifo = []
-        self._set = set()
+        self._set = OrderedDict()
 
     def __contains__(self, item: Any) -> bool:
         """Test if the BoundedSet contains item."""
+        self._access(item)
         return item in self._set
+
+    def _access(self, item: Any):
+        if item in self._set:
+            self._set.move_to_end(item)
 
     def add(self, item: Any):
         """Add an item to the set discarding the oldest item if necessary."""
-        if len(self._set) == self.max_items:
-            self._set.remove(self._fifo.pop(0))
-        self._fifo.append(item)
-        self._set.add(item)
+        self._access(item)
+        self._set[item] = None
+        if len(self._set) > self.max_items:
+            self._set.popitem(last=False)
 
 
 class ExponentialCounter:

--- a/tests/unit/models/test_util.py
+++ b/tests/unit/models/test_util.py
@@ -85,8 +85,11 @@ class TestStream(UnitTest):
             nonlocal counter
             counter += 1
             if counter % 2 == 0:
-                return initial_things
-            return [Thing(counter)] + initial_things[:-1]
+                things = initial_things
+            else:
+                things = [Thing(counter)] + initial_things[:-1]
+            for thing in things:
+                yield thing
 
         stream = stream_generator(generate)
         seen = set()

--- a/tests/unit/models/test_util.py
+++ b/tests/unit/models/test_util.py
@@ -75,7 +75,7 @@ class TestBoundedSet(UnitTest):
 
 
 class TestStream(UnitTest):
-    @mock.patch("time.sleep", return_value=None)
+    @mock.patch("asyncio.sleep", return_value=None)
     async def test_stream(self, _):
         Thing = namedtuple("Thing", ["fullname"])
         initial_things = [Thing(n) for n in reversed(range(100))]

--- a/tests/unit/models/test_util.py
+++ b/tests/unit/models/test_util.py
@@ -76,12 +76,12 @@ class TestBoundedSet(UnitTest):
 
 class TestStream(UnitTest):
     @mock.patch("time.sleep", return_value=None)
-    def test_stream(self, _):
+    async def test_stream(self, _):
         Thing = namedtuple("Thing", ["fullname"])
         initial_things = [Thing(n) for n in reversed(range(100))]
         counter = 99
 
-        def generate(limit, **kwargs):
+        async def generate(limit, **kwargs):
             nonlocal counter
             counter += 1
             if counter % 2 == 0:
@@ -90,10 +90,13 @@ class TestStream(UnitTest):
 
         stream = stream_generator(generate)
         seen = set()
-        for _ in range(400):
-            thing = next(stream)
+        loop_counter = 0
+        async for thing in stream:
             assert thing not in seen
             seen.add(thing)
+            counter += 1
+            if counter == 400:
+                break
 
 
 class TestPermissionsString(UnitTest):

--- a/tests/unit/models/test_util.py
+++ b/tests/unit/models/test_util.py
@@ -93,7 +93,6 @@ class TestStream(UnitTest):
 
         stream = stream_generator(generate)
         seen = set()
-        loop_counter = 0
         async for thing in stream:
             assert thing not in seen
             seen.add(thing)

--- a/tests/unit/models/test_util.py
+++ b/tests/unit/models/test_util.py
@@ -1,6 +1,13 @@
 """Test asyncpraw.models.util."""
-from asyncpraw.models.util import ExponentialCounter, permissions_string
+from collections import namedtuple
+from unittest import mock
 
+from asyncpraw.models.util import (
+    ExponentialCounter,
+    permissions_string,
+    stream_generator,
+    BoundedSet,
+)
 from .. import UnitTest
 
 
@@ -38,7 +45,58 @@ class TestExponentialCounter(UnitTest):
             counter.reset()
 
 
-class TestUtil(UnitTest):
+class TestBoundedSet(UnitTest):
+    def test_contains(self):
+        bset = BoundedSet(max_items=10)
+        bset.add(1)
+        assert 1 in bset
+
+    def test_bound(self):
+        bset = BoundedSet(max_items=10)
+        [bset.add(i) for i in range(11)]
+        assert len(bset._set) == 10
+        assert 0 not in bset
+
+    def test_lru_add(self):
+        bset = BoundedSet(max_items=10)
+        [bset.add(i) for i in range(10)]
+        bset.add(0)
+        bset.add(10)
+        assert 0 in bset
+        assert 1 not in bset
+
+    def test_lru_contains(self):
+        bset = BoundedSet(max_items=10)
+        [bset.add(i) for i in range(10)]
+        assert 0 in bset
+        bset.add(10)
+        assert 0 in bset
+        assert 1 not in bset
+
+
+class TestStream(UnitTest):
+    @mock.patch("time.sleep", return_value=None)
+    def test_stream(self, _):
+        Thing = namedtuple("Thing", ["fullname"])
+        initial_things = [Thing(n) for n in reversed(range(100))]
+        counter = 99
+
+        def generate(limit, **kwargs):
+            nonlocal counter
+            counter += 1
+            if counter % 2 == 0:
+                return initial_things
+            return [Thing(counter)] + initial_things[:-1]
+
+        stream = stream_generator(generate)
+        seen = set()
+        for _ in range(400):
+            thing = next(stream)
+            assert thing not in seen
+            seen.add(thing)
+
+
+class TestPermissionsString(UnitTest):
     PERMISSIONS = {"a", "b", "c"}
 
     def test_permissions_string__all_explicit(self):


### PR DESCRIPTION
This is the same patch as https://github.com/praw-dev/praw/pull/1547, but applied to the equivalent files in Async PRAW.

I haven't made any effort to test beyond importing the unit test patch, nor do I know anything about Async PRAW beyond some general knowledge of asyncio.