### PR TITLE
Include *.png files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     long_description=README,
     package_data={
         "": ["LICENSE.txt", "praw_license.txt"],
-        PACKAGE_NAME: ["*.ini", "images/*.jpg"],
+        PACKAGE_NAME: ["*.ini", "images/*.png"],
     },
     packages=find_packages(exclude=["tests", "tests.*", "tools", "tools.*"]),
     project_urls={


### PR DESCRIPTION
This includes the image that `_upload_media` falls back to for a thumbnail when submitting videos.

## References

- https://github.com/praw-dev/praw/pull/1810