### PR TITLE
Fix type hint in replace_more method

### DIFF
--- a/asyncpraw/models/comment_forest.py
+++ b/asyncpraw/models/comment_forest.py
@@ -179,7 +179,7 @@ class CommentForest:
         return comments
 
     async def replace_more(
-        self, limit: int = 32, threshold: int = 0
+        self, limit: Optional[int] = 32, threshold: int = 0
     ) -> List["asyncpraw.models.MoreComments"]:
         """Update the comment forest by resolving instances of MoreComments.
 


### PR DESCRIPTION
Limit argument in `replace_more` method can be int or None, but type hint was `int` instead of `Optional[int]`.