### PR TITLE
Bump aiofiles to 0.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     ),
     extras_require=extras,
     install_requires=[
-        "aiofiles <=0.6.0",
+        "aiofiles <=0.9.0",
         "aiohttp <4",
         "aiosqlite <=0.17.0",
         "asyncio_extras <=1.3.2",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     ),
     extras_require=extras,
     install_requires=[
-        "aiofiles <=0.9.0",
+        "aiofiles <1",
         "aiohttp <4",
         "aiosqlite <=0.17.0",
         "asyncio_extras <=1.3.2",


### PR DESCRIPTION
## Feature Summary and Justification

Aiofiles 0.7.0, 0.8.0 and 0.9.0 got no breaking changes. So bumping the version would allow users to install new versions of aiofiles. It also might be possible to bump it to `aiofiles<1` to make it future-safe.
