### PR TITLE
Revert `EditableMixin.edit` positional argument deprecation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Async PRAW follows `semantic versioning <http://semver.org/>`_.
 Unreleased
 ----------
 
+**Changed**
+
+- Revert :meth:`~.Comment.edit` positional argument deprecation.
+- Revert :meth:`~.Submission.edit` positional argument deprecation.
+
 **Fixed**
 
 - An issue where :class:`.ModmailConversation`'s ``messages`` attribute would only

--- a/asyncpraw/models/reddit/mixins/editable.py
+++ b/asyncpraw/models/reddit/mixins/editable.py
@@ -2,7 +2,6 @@
 from typing import TYPE_CHECKING, Union
 
 from ....const import API_PATH
-from ...util import _deprecate_args
 
 if TYPE_CHECKING:  # pragma: no cover
     import asyncpraw
@@ -27,9 +26,8 @@ class EditableMixin:
         """
         await self._reddit.post(API_PATH["del"], data={"id": self.fullname})
 
-    @_deprecate_args("body")
     async def edit(
-        self, *, body: str
+        self, body: str
     ) -> Union["asyncpraw.models.Comment", "asyncpraw.models.Submission"]:
         """Replace the body of the object with ``body``.
 
@@ -46,7 +44,7 @@ class EditableMixin:
             # construct the text of an edited comment
             # by appending to the old body:
             edited_body = comment.body + "Edit: thanks for the gold!"
-            await comment.edit(body=edited_body)
+            await comment.edit(edited_body)
 
         """
         data = {

--- a/asyncpraw/models/reddit/mixins/replyable.py
+++ b/asyncpraw/models/reddit/mixins/replyable.py
@@ -1,5 +1,5 @@
 """Provide the ReplyableMixin class."""
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 from ....const import API_PATH
 
@@ -10,13 +10,15 @@ if TYPE_CHECKING:  # pragma: no cover
 class ReplyableMixin:
     """Interface for :class:`.RedditBase` classes that can be replied to."""
 
-    async def reply(self, body: str) -> Optional["asyncpraw.models.Comment"]:
+    async def reply(
+        self, body: str
+    ) -> Optional[Union["asyncpraw.models.Comment", "asyncpraw.models.Message"]]:
         """Reply to the object.
 
         :param body: The Markdown formatted content for a comment.
 
-        :returns: A :class:`.Comment` object for the newly created comment or ``None``
-            if Reddit doesn't provide one.
+        :returns: A :class:`.Comment` or :class:`.Message` object for the newly created
+            comment or message or ``None`` if Reddit doesn't provide one.
 
         :raises: ``asyncprawcore.exceptions.Forbidden`` when attempting to reply to some
             items, such as locked submissions/comments or non-replyable messages.

--- a/tests/integration/models/reddit/test_comment.py
+++ b/tests/integration/models/reddit/test_comment.py
@@ -67,7 +67,7 @@ class TestComment(IntegrationTest):
         self.reddit.read_only = False
         with self.use_cassette():
             comment = Comment(self.reddit, "fwxxs5d")
-            await comment.edit(body="New text")
+            await comment.edit("New text")
             assert comment.body == "New text"
 
     async def test_enable_inbox_replies(self):

--- a/tests/integration/models/reddit/test_submission.py
+++ b/tests/integration/models/reddit/test_submission.py
@@ -66,7 +66,7 @@ class TestSubmission(IntegrationTest):
         self.reddit.read_only = False
         with self.use_cassette():
             submission = Submission(self.reddit, "hmkbt8")
-            await submission.edit(body="New text")
+            await submission.edit("New text")
             assert submission.selftext == "New text"
 
     @mock.patch("asyncio.sleep", return_value=None)
@@ -76,7 +76,7 @@ class TestSubmission(IntegrationTest):
         with self.use_cassette():
             submission = Submission(self.reddit, "hmkfoy")
             with pytest.raises(RedditAPIException):
-                await submission.edit(body="rewtwert")
+                await submission.edit("rewtwert")
 
     async def test_enable_inbox_replies(self):
         self.reddit.read_only = False


### PR DESCRIPTION
(cherry picked from commit praw-dev/praw/commit/3d729040c2d610e1a2d7a98342de6c0f7724b9b5)

## References

- https://github.com/praw-dev/praw/pull/1906
