### PR TITLE
Fix uploading files for submit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Unreleased
 **Fixed**
 
 - An issue with iterating :class:`.ModNote` when a user has more than a hundred notes.
+- An issue when uploading media to submit.
 
 7.6.1 (2022/11/28)
 ------------------

--- a/asyncpraw/models/reddit/subreddit.py
+++ b/asyncpraw/models/reddit/subreddit.py
@@ -702,8 +702,9 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
     async def _read_and_post_media(self, media_path, upload_url, upload_data):
         with open(media_path, "rb") as media:
+            upload_data["file"] = media
             response = await self._reddit._core._requestor._http.post(
-                upload_url, data=upload_data, files={"file": media}
+                upload_url, data=upload_data
             )
         return response
 


### PR DESCRIPTION
Fixes #224 
## Feature Summary and Justification

This fixes a call to `aiohttp.ClientSession.post` with invalid parameters when uploading media for posts.
