### PR TITLE
Unfreeze aiohttp version for python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "aiofiles",
-  "aiohttp <4; python_version < '3.12'",
-  "aiohttp==3.9.0b0; python_version == '3.12'",
+  "aiohttp <4",
   "aiosqlite <=0.17.0",
   "asyncprawcore >=2.1, <3",
   "update_checker >=0.18"


### PR DESCRIPTION
## Feature Summary and Justification

aiohttp's latest release (3.9.0) came out with support for python 3.12 so there should be no need to freeze aiohttp to a specific version now.

## References

- https://github.com/aio-libs/aiohttp/releases/tag/v3.9.0
