### PR TITLE
Add typing for package users

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -93,4 +93,5 @@ Source Contributors
 - zacc `@zacc <https://github.com/zacc>`_
 - Arkadiy Illarionov `@qarkai <https://github.com/qarkai>`_
 - c0d3rman `@c0d3rman <https://github.com/c0d3rman>`
+- Tim Harding <tim@timharding.co> `@tim-harding <https://github.com/tim-harding>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include CHANGES.rst LICENSE.txt README.rst praw_license.txt
 include asyncpraw/praw.ini
 include "asyncpraw/images/PRAW logo.png"
+include asyncpraw/py.typed


### PR DESCRIPTION
## Feature Summary and Justification

This pull request provides typing for package users. Although the package itself is typed, the types are not currently available to tools like `mypy` when the package is used as a dependency. This minor code change addresses that with [PEP 561](https://peps.python.org/pep-0561/#type-checker-module-resolution-order). I am using this fork as a dependency for my bot project and can confirm that the typing works. 