### PR TITLE
(doc) Mention requiring closing Reddit http connection

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,6 +31,7 @@ Documentation Contributors
 - Johanna Rührig `@TheRealVira <https://github.com/TheRealVira>`_
 - Sam Snarr `@sss-ng <https://github.com/sss-ng>`_
 - Moshe Dicker `@dickermoshe <https://github.com/dickermoshe>`_
+- Andrew Chen Wang `@Andrew-Chen-Wang <https://github.com/Andrew-Chen-Wang>`_
 - Add "Name <email (optional)> and github profile link" above this line.
 
 PRAW Author

--- a/docs/getting_started/quick_start.rst
+++ b/docs/getting_started/quick_start.rst
@@ -157,6 +157,25 @@ to read-only mode whenever you want:
     If you are uncomfortable hard-coding your credentials into your program, there are
     some options available to you. Please see: :ref:`configuration`.
 
+Close Connections in :class:`.Reddit`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The asynchronous context requires closing your session when you finish using Reddit:
+
+.. code-block:: python
+
+    reddit = asyncpraw.Reddit(...)
+    await reddit.close()
+
+Or, you can use an asynchronous context manager:
+
+.. code-block:: python
+
+    async with asyncpraw.Reddit(...) as reddit:
+        # do stuff with `reddit`
+        print(await reddit.user.me())
+    # connection is closed
+
 Obtain a :class:`.Subreddit`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I noticed the Reddit instance has an `__aexit__` method that should auto close, but it's no where mentioned in the docs.

You'll get an error without explicitly closing the connection if you were to follow the get started docs

The docs in general are not really up to date either. The tutorials are also a bit outdated:

```
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x105e36900>
Unclosed connector
connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x105e98d70>, 436028.214513125)])']
connector: <aiohttp.connector.TCPConnector object at 0x105e36a50>
Exception ignored in: <function _DeleteDummyThreadOnDel.__del__ at 0x100d794e0>
Traceback (most recent call last):
  File "/Users/andrew/.local/share/mise/installs/python/3.13.3/lib/python3.13/threading.py", line 1383, in __del__
TypeError: 'NoneType' object does not support the context manager protocol
```

## Usage of `__del__` for auto closing in async code bases

There is some kind of class in this lib that's setting `__del__` and calling `close()` that should be deleted from the code base.

Even adding `.close()` shows

```
Exception ignored in: <function _DeleteDummyThreadOnDel.__del__ at 0x1006b54e0>
Traceback (most recent call last):
  File "/Users/andrew/.local/share/mise/installs/python/3.13.3/lib/python3.13/threading.py", line 1383, in __del__
TypeError: 'NoneType' object does not support the context manager protocol
```

It's noted that trying to close the connection using `__del__` doesn't work here in the redis-py thread: 

https://github.com/redis/redis-py/blob/120517f88671469888a747d8e1ca1d1c2348b301/redis/asyncio/connection.py#L227

```python
   def __del__(self, _warnings: Any = warnings):
        # For some reason, the individual streams don't get properly garbage
        # collected and therefore produce no resource warnings.  We add one
        # here, in the same style as those from the stdlib.
        if getattr(self, "_writer", None):
            _warnings.warn(
                f"unclosed Connection {self!r}", ResourceWarning, source=self
            )

            try:
                asyncio.get_running_loop()
                self._close()
            except RuntimeError:
                # No actions been taken if pool already closed.
                pass
```

The problem ends up being the event loop is already closed at the end of the program *sometimes* (sometimes it's still open; it's a non-zero chance essentially). https://github.com/redis/redis-py/pull/2999


