### PR TITLE
Update Config to use importlib for defaults

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -94,5 +94,6 @@ Source Contributors
 - zacc `@zacc <https://github.com/zacc>`_
 - Arkadiy Illarionov `@qarkai <https://github.com/qarkai>`_
 - c0d3rman `@c0d3rman <https://github.com/c0d3rman>`
+- Joe Kerhin `@jkerhin <https://github.com/jkerhin>`_
 - Aaron Becker `@aaronjbecker <https://github.com/aaronjbecker>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/asyncpraw/config.py
+++ b/asyncpraw/config.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import configparser
+import importlib
+import importlib.resources
 import os
-import sys
 from pathlib import Path
 from threading import Lock
 from types import MappingProxyType
@@ -49,7 +50,8 @@ class Config:
             interpolator_class = None
 
         config = configparser.ConfigParser(interpolation=interpolator_class)
-        module_dir = Path(sys.modules[__name__].__file__).parent
+        with importlib.resources.open_text(__package__, "praw.ini") as hdl:
+            config.read_file(hdl)
 
         if "APPDATA" in os.environ:  # Windows
             os_config_path = Path(os.environ["APPDATA"])
@@ -60,10 +62,10 @@ class Config:
         else:
             os_config_path = None
 
-        locations = [str(module_dir / "praw.ini"), "praw.ini"]
+        locations = ["praw.ini"]
 
         if os_config_path is not None:
-            locations.insert(1, str(os_config_path / "praw.ini"))
+            locations.insert(0, str(os_config_path / "praw.ini"))
 
         config.read(locations)
         cls.CONFIG = config

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,10 +22,10 @@ class TestConfig:
                 del os.environ[env_name]
         os.environ[environment] = "/MOCK"
 
-        module_dir = Path(sys.modules["asyncpraw"].__file__).parent
-        environ_path = Path("/MOCK") / (".config" if environment == "HOME" else "") / "praw.ini"
+        environ_path = (
+            Path("/MOCK") / (".config" if environment == "HOME" else "") / "praw.ini"
+        )
         locations = [
-            str(module_dir / "praw.ini"),
             str(environ_path),
             "praw.ini",
         ]
@@ -82,8 +82,7 @@ class TestConfig:
                 prev_environment[key] = os.environ[key]
                 del os.environ[key]
 
-        module_dir = os.path.dirname(sys.modules["asyncpraw"].__file__)
-        locations = [os.path.join(module_dir, "praw.ini"), "praw.ini"]
+        locations = ["praw.ini"]
 
         try:
             Config._load_config()


### PR DESCRIPTION
Makes praw "zip-safe" by using importlib to read the default praw.ini instead of trying to build a path to the ini file on disk.

Prior to this patch, attempting to use `praw` in a zipapp will exit with an exception because the `praw.ini` file does not actually exist in the system filesystem.

(cherry picked from commit praw-dev/praw@1fd51b01802c971d5300fafc13383a57059515f6)

Fixes # (provide issue number if applicable)

## Feature Summary and Justification

This pull request provides ...

## References

- https://github.com/praw-dev/praw/pull/2038
