### PR TITLE
Recommend uv for installation; update contributor docs for uv

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -36,17 +36,16 @@ to the person asking the question.
    commenting on the issue. This act will hopefully minimize any duplicate work.
 2. You will need to clone the repository and open the project in the IDE of your choice.
    Note: the following commands need to executed within the project directory.
-3. Install the development dependencies with ``pip install -e ".[dev]"``. This will
-   install Async PRAW in an editable state which will make development, testing, and
-   debugging easier. This will also install all the needed dependencies for linting and
-   testing. `See here`_ for more information on installing the development dependencies.
+3. Install the development dependencies with ``uv sync``. This will install Async PRAW
+   in an editable state which will make development, testing, and debugging easier. This
+   will also install all the needed dependencies for linting and testing. `See here`_
+   for more information on installing the development dependencies.
 4. Before committing, make sure to install pre-commit_ and the pre-commit hooks, which
    ensures any new code conforms to our quality and style guidelines. To do so, install
-   the development dependencies mentioned previously or just the linting dependencies
-   with ``pip install ".[lint]"``, then install the hooks with ``pre-commit install``.
-   They will now run automatically every time you commit. If one of the hooks changes
-   one or more files, the commit will automatically abort, so you can double-check the
-   changes. If everything looks good try committing again.
+   the development dependencies mentioned previously, then install the hooks with ``uv
+   run pre-commit install``. They will now run automatically every time you commit. If
+   one of the hooks changes one or more files, the commit will automatically abort, so
+   you can double-check the changes. If everything looks good try committing again.
 5. Prior to creating a pull request, run the ``pre_push.py`` script. This runs the
    pre-commit suite on all files, as well as builds the docs. You'll need to have
    installed the linting dependencies first (see previous step).
@@ -58,8 +57,8 @@ to the person asking the question.
 8. Ensure that your code change has complete test coverage. Tests on methods that do not
    require fetching data from Reddit, e.g., method argument validation, should be saved
    as a unit test. Tests that hit Reddit's servers will be an integration test and all
-   network activity will be recorded via vcrpy. The required packages can be installed
-   with ``pip install ".[test]"``.
+   network activity will be recorded via vcrpy. The required packages are included in
+   the development dependencies.
 9. Feel free to check on the status of your pull request periodically by adding a
    comment.
 

--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,15 @@ you're set.
  Installation
 **************
 
-Async PRAW is supported on Python 3.9+. The recommended way to install Async PRAW is via
-`pip <https://pypi.python.org/pypi/pip>`_.
+Async PRAW is supported on Python 3.10+. The recommended way to install Async PRAW is
+with `uv <https://docs.astral.sh/uv/>`_.
+
+.. code-block:: bash
+
+    uv add asyncpraw
+
+Alternatively, Async PRAW can be installed via `pip
+<https://pypi.python.org/pypi/pip>`_:
 
 .. code-block:: bash
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -2,8 +2,14 @@
  Installing Async PRAW
 #######################
 
-Async PRAW supports Python 3.9+. The recommended way to install Async PRAW is via
-``pip``.
+Async PRAW supports Python 3.10+. The recommended way to install Async PRAW is with `uv
+<https://docs.astral.sh/uv/>`_.
+
+.. code-block:: bash
+
+    uv add asyncpraw
+
+Alternatively, Async PRAW can be installed via ``pip``:
 
 .. code-block:: bash
 
@@ -29,6 +35,12 @@ Async PRAW can be updated by running:
 
 .. code-block:: bash
 
+    uv sync --upgrade-package asyncpraw
+
+or with pip:
+
+.. code-block:: bash
+
     pip install --upgrade asyncpraw
 
 ***************************
@@ -37,6 +49,12 @@ Async PRAW can be updated by running:
 
 Older versions of Async PRAW can be installed by specifying the version number as part
 of the installation command:
+
+.. code-block:: bash
+
+    uv add asyncpraw==7.1.0
+
+or with pip:
 
 .. code-block:: bash
 

--- a/docs/package_info/contributing.rst
+++ b/docs/package_info/contributing.rst
@@ -11,63 +11,27 @@ decreases bug-potential and makes it faster to understand how everything works t
 *****************************************
 
 This section will cover the recommended steps to get you started with contributing to
-Async PRAW.
-
-Create a Virtual Environment
-============================
-
-It is strongly recommended to use a virtual environment to isolate your development
-environment. This is a good idea because it will make managing the needed dependencies
-and their versions much easier. For more information, see the `venv documentation`_.
-Assuming you have the minimum Python version required for Async PRAW, you can create a
-virtual environment with the following commands from the root of the cloned project
-directory:
-
-.. code-block:: bash
-
-    python3 -m venv .venv
-
-Next you need to activate the virtual environment. This is done by running the
-following:
-
-**MacOS/Linux**:
-
-.. code-block:: bash
-
-    source .venv/bin/activate
-
-**Windows Command Prompt**
-
-.. code-block:: bat
-
-    .venv\Scripts\activate.bat
-
-.. _install_dev_deps:
+Async PRAW. .. _install_dev_deps:
 
 Install Development Dependencies
 ================================
 
-Next, you will need to install the dependencies development dependencies. This is done
-by running the following:
+Async PRAW is managed with uv_, which handles creating a virtual environment and
+installing the locked dependencies in one step. After `installing uv
+<https://docs.astral.sh/uv/getting-started/installation/>`_, run the following from the
+root of the cloned project directory:
 
 .. code-block:: bash
 
-    pip install -e .[dev]
-
-.. important::
-
-    If you are using ``zsh`` for your shell, you will need to double-quote ``.[dev]``
-    like so:
-
-    .. code-block:: zsh
-
-        pip install -e ".[dev]"
+    uv sync
 
 .. note::
 
-    The ``-e`` tells pip to install Async PRAW in an editable state. This will allow for
-    easier testing and debugging. The ``[dev]`` extra will install all development
-    dependencies. This includes the dependencies for both linting and testing.
+    This creates a ``.venv`` virtual environment with Async PRAW installed in an
+    editable state, which allows for easier testing and debugging, and installs the
+    ``dev`` dependency group, which includes the ``lint`` and ``test`` groups. Prefix
+    commands with ``uv run`` (e.g., ``uv run pytest``) to run them inside that
+    environment without activating it.
 
 ************
  Code Style
@@ -85,25 +49,20 @@ suite and the docs build prior to submitting a pull request.
 .. note::
 
     In order to use the pre-commit hooks and the ``pre_push.py`` dependencies, you must
-    either install the development dependencies as outlined in the
-    :ref:`install_dev_deps` section above or you must install the ``[lint]`` extra
-    manually:
-
-    .. code-block:: bash
-
-        pip install -e .[lint]
+    install the development dependencies as outlined in the :ref:`install_dev_deps`
+    section above.
 
 To install the pre-commit hooks to automatically run when you commit, run the following:
 
 .. code-block:: bash
 
-    pre-commit install
+    uv run pre-commit install
 
 To run all the needed checks and to ensure the docs build correctly, run the following:
 
 .. code-block:: bash
 
-    ./pre_push.py
+    uv run ./pre_push.py
 
 .. _asyncpraw_specific_guidelines:
 
@@ -317,6 +276,6 @@ Please also read the `Contributing Guidelines`_
 
 .. _r/python: https://www.reddit.com/r/python
 
-.. _vcrpy: https://vcrpy.readthedocs.io/en/latest
+.. _uv: https://docs.astral.sh/uv/
 
-.. _venv documentation: https://docs.python.org/3/library/venv.html
+.. _vcrpy: https://vcrpy.readthedocs.io/en/latest


### PR DESCRIPTION
User-facing installation docs now lead with 'uv add asyncpraw' and
keep pip as the alternative; contributor docs replace the removed
extras (pip install -e .[dev]/[lint]/[test]) with uv sync and
dependency groups. Python floor references updated to 3.10+.
