### PR TITLE
Refer to the package as asyncpraw in the changelog preamble

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Change Log
 ############
 
-Async PRAW follows `semantic versioning <https://semver.org/>`_.
+asyncpraw follows `semantic versioning <https://semver.org/>`_.
 
 ************
  Unreleased


### PR DESCRIPTION
praw-release's `bump` command validates the changelog preamble against the package name, so `Async PRAW follows ...` would fail the header check. This aligns the preamble with prawcore/asyncprawcore (`asyncpraw follows ...`). Verified locally that `praw-release bump asyncpraw 8.0.0` succeeds with this change. Companion to praw-dev/praw#2109.