### PR TITLE
Use update_checker's async API and require update_checker 1.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
 
 - Drop support for Python 3.9, which was end-of-life on 2025-10-31.
 - Bumped asyncprawcore to 3.0.2.
+- Require ``update_checker[async] >=1.0, <2.0`` and perform the update check using its
+  native async API on the first request, instead of a blocking call during ``Reddit``
+  initialization. The 1.0 release is dependency-free, dropping ``requests`` from Async
+  PRAW's transitive dependencies.
 - Drop support for Python 3.8, which was end-of-life on 2024-10-07.
 - Change ``Reddit.user.me`` to raise :class:`.ReadOnlyException` when called in
   :attr:`.read_only` mode.

--- a/asyncpraw/reddit.py
+++ b/asyncpraw/reddit.py
@@ -32,7 +32,7 @@ from asyncpraw.exceptions import ClientException, MissingRequiredAttributeExcept
 from asyncpraw.objector import Objector
 
 try:
-    from update_checker import update_check
+    from update_checker import async_update_check
 
     UPDATE_CHECKER_MISSING = False
 except ImportError:  # pragma: no cover
@@ -241,7 +241,6 @@ class Reddit:
         if self.config.client_secret is self.config.CONFIG_NOT_SET:
             msg = f"{required_message.format('client_secret')}\nFor installed applications this value must be set to None via a keyword argument to the Reddit class constructor."
             raise MissingRequiredAttributeException(msg)
-        self._check_for_update()
         self._prepare_objector()
         self.requestor = self._prepare_asyncprawcore(requestor_class=requestor_class, requestor_kwargs=requestor_kwargs)
 
@@ -437,11 +436,11 @@ class Reddit:
 
         """
 
-    def _check_for_update(self) -> None:
+    async def _check_for_update(self) -> None:
         if UPDATE_CHECKER_MISSING:
             return
         if not Reddit.update_checked and self.config.check_for_updates:
-            update_check(__package__, __version__)
+            await async_update_check(package_name=__package__, package_version=__version__)
             Reddit.update_checked = True
 
     def _handle_rate_limit(self, exception: RedditAPIException) -> int | float | None:
@@ -908,6 +907,7 @@ class Reddit:
         :param path: The path to fetch.
 
         """
+        await self._check_for_update()
         if data and json:
             msg = "At most one of 'data' or 'json' is supported."
             raise ClientException(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
   "aiohttp <4",
   "asyncprawcore >=3.0.1, <4",
   "defusedxml ==0.7.1",
-  "update_checker >=0.18"
+  "update_checker[async] >=1.0, <2.0"
 ]
 dynamic = ["version", "description"]
 keywords = ["reddit", "api", "wrapper", "asyncpraw", "praw", "async", "asynchronous"]

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -28,17 +28,21 @@ class MockClientSession:
 class TestReddit(UnitTest):
     REQUIRED_DUMMY_SETTINGS = {x: "dummy" for x in ["client_id", "client_secret", "user_agent"]}
 
-    @mock.patch("asyncpraw.reddit.update_check", create=True)
+    @mock.patch("asyncpraw.reddit.UPDATE_CHECKER_MISSING", False)
+    @mock.patch("asyncpraw.reddit.Reddit.update_checked", False)
+    @mock.patch("asyncpraw.reddit.async_update_check", create=True, new_callable=AsyncMock)
     async def test_check_for_updates(self, mock_update_check):
-        Reddit(check_for_updates="1", **self.REQUIRED_DUMMY_SETTINGS)
+        reddit = Reddit(check_for_updates="1", **self.REQUIRED_DUMMY_SETTINGS)
+        await reddit._check_for_update()
         assert Reddit.update_checked
-        mock_update_check.assert_called_with("asyncpraw", __version__)
+        mock_update_check.assert_called_with(package_name="asyncpraw", package_version=__version__)
 
     @mock.patch("asyncpraw.reddit.Reddit.update_checked", False)
     @mock.patch("asyncpraw.reddit.UPDATE_CHECKER_MISSING", True)
-    @mock.patch("asyncpraw.reddit.update_check", create=True)
+    @mock.patch("asyncpraw.reddit.async_update_check", create=True, new_callable=AsyncMock)
     async def test_check_for_updates_update_checker_missing(self, mock_update_check):
-        Reddit(check_for_updates="1", **self.REQUIRED_DUMMY_SETTINGS)
+        reddit = Reddit(check_for_updates="1", **self.REQUIRED_DUMMY_SETTINGS)
+        await reddit._check_for_update()
         assert not Reddit.update_checked
         assert not mock_update_check.called
 

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "asyncprawcore" },
     { name = "defusedxml" },
-    { name = "update-checker" },
+    { name = "update-checker", extra = ["async"] },
 ]
 
 [package.dev-dependencies]
@@ -228,7 +228,7 @@ requires-dist = [
     { name = "aiohttp", specifier = "<4" },
     { name = "asyncprawcore", specifier = ">=3.0.1,<4" },
     { name = "defusedxml", specifier = "==0.7.1" },
-    { name = "update-checker", specifier = ">=0.18" },
+    { name = "update-checker", extras = ["async"], specifier = ">=1.0,<2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1806,14 +1806,16 @@ wheels = [
 
 [[package]]
 name = "update-checker"
-version = "0.18.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/0b/1bec4a6cc60d33ce93d11a7bcf1aeffc7ad0aa114986073411be31395c6f/update_checker-0.18.0.tar.gz", hash = "sha256:6a2d45bb4ac585884a6b03f9eade9161cedd9e8111545141e9aa9058932acb13", size = 6699, upload-time = "2020-08-04T07:08:50.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/0d/cdf2a0bc53f2b0b85a9cc7a81d0c5fa666dc140d26a1797ddf8ce4a24d0d/update_checker-1.0.0.tar.gz", hash = "sha256:bfcac66414572a82a98ea8c8633bf1ce5d102750e3b93469b89b30aa845cd1d7", size = 9600, upload-time = "2026-06-08T07:08:20.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/ba/8dd7fa5f0b1c6a8ac62f8f57f7e794160c1f86f31c6d0fb00f582372a3e4/update_checker-0.18.0-py3-none-any.whl", hash = "sha256:cbba64760a36fe2640d80d85306e8fe82b6816659190993b7bdabadee4d4bbfd", size = 7008, upload-time = "2020-08-04T07:08:49.51Z" },
+    { url = "https://files.pythonhosted.org/packages/51/f5/a264987b052d61c172d23eec92935480535fd32e45357bd6557fa2c687d5/update_checker-1.0.0-py3-none-any.whl", hash = "sha256:5837640948ff21820ba3ea881fb4bed5abefb39037895c6447f5e712236d60c6", size = 10618, upload-time = "2026-06-08T07:08:19.782Z" },
+]
+
+[package.optional-dependencies]
+async = [
+    { name = "aiohttp" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates the update_checker dependency to the new 1.0 release and switches the update check to update_checker's native async API.

## Changes

- **Dependency:** `update_checker >=0.18` → `update_checker[async] >=1.0, <2.0`. The 1.0 release is dependency-free, so this also drops `requests` from Async PRAW's transitive dependency tree. The `[async]` extra pulls aiohttp, which Async PRAW already depends on.
- **Async update check:** `_check_for_update` is now a coroutine that awaits `async_update_check(package_name=..., package_version=...)` instead of calling the blocking synchronous `update_check`.
- **Timing:** the check moved out of the synchronous `Reddit.__init__` (where a blocking network call doesn't belong in an async library) to the top of `async def request`, so it runs once on the first request. Guarded by the existing `Reddit.update_checked` flag, so it's a no-op on subsequent requests.
- Call now uses keyword arguments.

## Tests

`_check_for_update` unit tests updated to await the coroutine and patch `async_update_check` with an `AsyncMock`. Full unit suite passes (283 tests); `update_checker[async] >=1.0` resolves and installs cleanly; `asyncpraw/reddit.py` adds no new ruff errors and is format-clean.