### PR TITLE
Bump urllib3 from 1.26.20 to 2.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ test = [
   "pytest >=8",
   "pytest-asyncio >=1.0.0",
   "pytest-vcr ==1.*",
-  "urllib3 ==1.*",
   "vcrpy >=8.1.1"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -187,7 +187,6 @@ dev = [
     { name = "sphinx-autodoc-typehints", version = "3.10.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinxcontrib-trio" },
     { name = "tox-uv" },
-    { name = "urllib3" },
     { name = "vcrpy" },
 ]
 docs = [
@@ -218,7 +217,6 @@ test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-vcr" },
-    { name = "urllib3" },
     { name = "vcrpy" },
 ]
 
@@ -246,7 +244,6 @@ dev = [
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinxcontrib-trio" },
     { name = "tox-uv", specifier = ">=1.22.1" },
-    { name = "urllib3", specifier = "==1.*" },
     { name = "vcrpy", specifier = ">=8.1.1" },
 ]
 docs = [
@@ -269,7 +266,6 @@ test = [
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-vcr", specifier = "==1.*" },
-    { name = "urllib3", specifier = "==1.*" },
     { name = "vcrpy", specifier = ">=8.1.1" },
 ]
 
@@ -1811,11 +1807,11 @@ async = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.20"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380, upload-time = "2024-08-29T15:43:11.37Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225, upload-time = "2024-08-29T15:43:08.921Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes #332 (the Dependabot urllib3 bump), which was blocked by the explicit `urllib3 ==1.*` test pin.

That pin was a stale leftover. urllib3 is only a transitive dependency here (asyncpraw runs on aiohttp; urllib3 comes in via `requests`), and both `requests` and vcrpy 8 (#341) support urllib3 2.x. Dropping the pin lets urllib3 resolve to 2.7.0.

Verified: 947 passed, 1 skipped, 100% coverage, pre-commit clean.