### PR TITLE
Add exception_handler to stream_generator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
 
 **Added**
 
+- An ``exception_handler`` keyword argument to :func:`.stream_generator` (and thus all
+  ``stream`` methods) that is invoked with any exception raised while fetching items,
+  allowing the stream to resume rather than terminate. Re-raise from the handler to stop
+  the stream.
 - :meth:`.Redditor.overview` to iterate over a Redditor's combined comments and
   submissions, mirroring the user overview page on Reddit.
 - Add support for Python 3.13.

--- a/asyncpraw/models/util.py
+++ b/asyncpraw/models/util.py
@@ -39,6 +39,7 @@ async def stream_generator(
     attribute_name: str = "fullname",
     continue_after_id: str | None = None,
     exclude_before: bool = False,
+    exception_handler: Callable[[Exception], None] | None = None,
     pause_after: int | None = None,
     skip_existing: bool = False,
     **function_kwargs: Any,
@@ -50,6 +51,12 @@ async def stream_generator(
     :param attribute_name: The field to use as an ID (default: ``"fullname"``).
     :param exclude_before: When ``True`` does not pass ``params`` to ``function``
         (default: ``False``).
+    :param exception_handler: A callable that is invoked with the exception raised while
+        fetching items, instead of letting it propagate and terminate the stream. After
+        the handler returns, the stream waits (using the same exponential backoff
+        applied to empty responses) and then resumes. To stop the stream, re-raise the
+        exception (or raise a new one) from within the handler. When ``None``,
+        exceptions propagate and terminate the stream as before (default: ``None``).
     :param pause_after: An integer representing the number of requests that result in no
         new items before this function yields ``None``, effectively introducing a pause
         into the stream. A negative value yields ``None`` after items from a single
@@ -121,6 +128,31 @@ async def stream_generator(
                 continue
             print(comment)
 
+    To keep a stream alive across transient errors (e.g., network issues or server
+    errors) rather than having it terminate, pass an ``exception_handler``:
+
+    .. code-block:: python
+
+        def log_exception(exception):
+            print(f"Stream error, retrying: {exception}")
+
+
+        subreddit = await reddit.subreddit("test")
+        async for comment in subreddit.stream.comments(exception_handler=log_exception):
+            print(comment)
+
+    The handler can stop the stream for errors it considers fatal by re-raising:
+
+    .. code-block:: python
+
+        from asyncprawcore.exceptions import Forbidden
+
+
+        def handle_exception(exception):
+            if isinstance(exception, Forbidden):
+                raise exception
+            print(f"Stream error, retrying: {exception}")
+
     """
     before_attribute = continue_after_id
     exponential_counter = ExponentialCounter(max_counter=16)
@@ -137,7 +169,15 @@ async def stream_generator(
             without_before_counter = (without_before_counter + 1) % 30
         if not exclude_before:
             function_kwargs["params"] = {"before": before_attribute}
-        for item in reversed([result async for result in function(limit=limit, **function_kwargs)]):
+        try:
+            items = [result async for result in function(limit=limit, **function_kwargs)]
+        except Exception as exception:
+            if exception_handler is None:
+                raise
+            exception_handler(exception)
+            await asyncio.sleep(exponential_counter.counter())
+            continue
+        for item in reversed(items):
             attribute = getattr(item, attribute_name)
             if attribute in seen_attributes:
                 continue

--- a/tests/unit/models/test_util.py
+++ b/tests/unit/models/test_util.py
@@ -2,6 +2,8 @@
 
 from collections import namedtuple
 
+import pytest
+
 from asyncpraw.models.util import (
     BoundedSet,
     ExponentialCounter,
@@ -147,3 +149,48 @@ class TestStream(UnitTest):
             counter += 1
             if counter == 400:
                 break
+
+    async def test_stream__exception_handler(self, monkeypatch):
+        async def _sleep(*_):
+            pass
+
+        monkeypatch.setattr("asyncpraw.models.util.asyncio.sleep", _sleep)
+        Thing = namedtuple("Thing", ["fullname"])
+        handled = []
+        responses = [RuntimeError("boom"), [Thing(1)], [Thing(2)]]
+
+        async def generate(limit, **kwargs):
+            response = responses.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            for item in response:
+                yield item
+
+        stream = stream_generator(generate, exception_handler=handled.append)
+        # The first fetch raises and is handled; the stream then resumes and keeps
+        # yielding new items on subsequent iterations.
+        assert (await self.async_next(stream)).fullname == 1
+        assert (await self.async_next(stream)).fullname == 2
+        assert len(handled) == 1
+        assert str(handled[0]) == "boom"
+
+    async def test_stream__exception_handler__reraise(self):
+        async def generate(limit, **kwargs):
+            raise RuntimeError("boom")
+            yield  # unreachable; makes ``generate`` an async generator
+
+        def handler(exception):
+            raise exception
+
+        stream = stream_generator(generate, exception_handler=handler)
+        with pytest.raises(RuntimeError):
+            await self.async_next(stream)
+
+    async def test_stream__exception_propagates_without_handler(self):
+        async def generate(limit, **kwargs):
+            raise RuntimeError("boom")
+            yield  # unreachable; makes ``generate`` an async generator
+
+        stream = stream_generator(generate)
+        with pytest.raises(RuntimeError):
+            await self.async_next(stream)


### PR DESCRIPTION
## Summary

Mirrors praw-dev/praw#2128 in Async PRAW. Adds an optional `exception_handler` keyword argument to `stream_generator` (and thus all `stream` methods) that is invoked with any exception raised while fetching items, allowing the stream to resume rather than terminate. Re-raise from the handler to stop the stream.

```python
def log_exception(exception):
    print(f"Stream error, retrying: {exception}")


subreddit = await reddit.subreddit("test")
async for comment in subreddit.stream.comments(exception_handler=log_exception):
    print(comment)
```

When `exception_handler` is `None` (the default), behavior is unchanged: exceptions propagate and terminate the stream.

## Testing

- Three new unit tests: handled-then-resumes, re-raise-to-stop, and propagation without a handler.
- Full suite: 955 passed, 1 skipped, **100% coverage** (`coverage run --source asyncpraw`).