### PR TITLE
Add timezone-aware datetime properties for Unix-time fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,15 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
 
 **Added**
 
+- :attr:`~.Comment.created_datetime` to objects with a creation time (for example
+  :class:`.Comment`, :class:`.Submission`, :class:`.Redditor`, :class:`.Subreddit`,
+  :class:`.Collection`, and :class:`.ModNote`), returning a timezone-aware
+  :class:`datetime.datetime`.
+- :attr:`~.Collection.updated_datetime` to :class:`.Collection`,
+  :attr:`~.PollData.voting_end_datetime` to :class:`.PollData`, and
+  :attr:`~.Comment.edited_datetime` to :class:`.Comment` and :class:`.Submission`
+  (``None`` when the object has not been edited), all returning timezone-aware
+  :class:`datetime.datetime` objects.
 - An ``exception_handler`` keyword argument to :func:`.stream_generator` (and thus all
   ``stream`` methods) that is invoked with any exception raised while fetching items,
   allowing the stream to resume rather than terminate. Re-raise from the handler to stop

--- a/asyncpraw/models/base.py
+++ b/asyncpraw/models/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -24,6 +25,19 @@ class AsyncPRAWBase:
         value = deepcopy(arguments[key]) if key in arguments else {}
         value.update(new_arguments)
         arguments[key] = value
+
+    @staticmethod
+    def _to_local_datetime(timestamp: float) -> datetime:
+        """Return ``timestamp`` as a timezone-aware :class:`datetime.datetime`.
+
+        :param timestamp: A `Unix Time`_ value, in seconds.
+
+        The returned object is localized to the system's timezone.
+
+        .. _unix time: https://en.wikipedia.org/wiki/Unix_time
+
+        """
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc).astimezone()
 
     @classmethod
     def parse(cls, data: dict[str, Any], reddit: asyncpraw.Reddit) -> AsyncPRAWBase:

--- a/asyncpraw/models/mod_note.py
+++ b/asyncpraw/models/mod_note.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from asyncpraw.endpoints import API_PATH
 from asyncpraw.models.base import AsyncPRAWBase
+from asyncpraw.models.reddit.mixins import CreatedMixin
 
 
-class ModNote(AsyncPRAWBase):
+class ModNote(CreatedMixin, AsyncPRAWBase):
     """Represent a moderator note.
 
     .. include:: ../../typical_attributes.rst
@@ -44,6 +45,8 @@ class ModNote(AsyncPRAWBase):
     .. _unix time: https://en.wikipedia.org/wiki/Unix_time
 
     """
+
+    _created_at_attribute = "created_at"
 
     def __eq__(self, other: ModNote | str | object) -> bool:
         """Return whether the other instance equals the current."""

--- a/asyncpraw/models/reddit/collections.py
+++ b/asyncpraw/models/reddit/collections.py
@@ -8,6 +8,7 @@ from asyncpraw.const import API_PATH
 from asyncpraw.exceptions import ClientException
 from asyncpraw.models.base import AsyncPRAWBase
 from asyncpraw.models.reddit.base import RedditBase
+from asyncpraw.models.reddit.mixins import CreatedMixin
 from asyncpraw.models.reddit.redditor import Redditor
 from asyncpraw.models.reddit.submission import Submission
 from asyncpraw.models.reddit.subreddit import Subreddit
@@ -15,6 +16,7 @@ from asyncpraw.util.cache import cachedproperty
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from datetime import datetime
 
     import asyncpraw.models
 
@@ -412,7 +414,7 @@ class SubredditCollections(AsyncPRAWBase):
         self.subreddit = subreddit
 
 
-class Collection(RedditBase):
+class Collection(CreatedMixin, RedditBase):
     """Class to represent a :class:`.Collection`.
 
     Obtain an instance via:
@@ -454,6 +456,17 @@ class Collection(RedditBase):
     """
 
     STR_FIELD = "collection_id"
+
+    _created_at_attribute = "created_at_utc"
+
+    @property
+    def updated_datetime(self) -> datetime:
+        """Return the last update time as a timezone-aware :class:`datetime.datetime`.
+
+        The returned object is localized to the system's timezone.
+
+        """
+        return self._to_local_datetime(self.last_update_utc)
 
     @cachedproperty
     def mod(self) -> CollectionModeration:

--- a/asyncpraw/models/reddit/comment.py
+++ b/asyncpraw/models/reddit/comment.py
@@ -8,7 +8,13 @@ from asyncpraw.const import API_PATH
 from asyncpraw.exceptions import ClientException, InvalidURL
 from asyncpraw.models.comment_forest import CommentForest
 from asyncpraw.models.reddit.base import RedditBase
-from asyncpraw.models.reddit.mixins import FullnameMixin, InboxableMixin, ThingModerationMixin, UserContentMixin
+from asyncpraw.models.reddit.mixins import (
+    CreatedMixin,
+    FullnameMixin,
+    InboxableMixin,
+    ThingModerationMixin,
+    UserContentMixin,
+)
 from asyncpraw.models.reddit.redditor import Redditor
 from asyncpraw.models.reddit.submission import Submission
 from asyncpraw.models.reddit.subreddit import Subreddit
@@ -18,7 +24,7 @@ if TYPE_CHECKING:
     import asyncpraw.models
 
 
-class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
+class Comment(InboxableMixin, UserContentMixin, FullnameMixin, CreatedMixin, RedditBase):
     """A class that represents a Reddit comment.
 
     .. include:: ../../typical_attributes.rst

--- a/asyncpraw/models/reddit/live.py
+++ b/asyncpraw/models/reddit/live.py
@@ -8,7 +8,7 @@ from asyncpraw.const import API_PATH
 from asyncpraw.models.list.redditor import RedditorList
 from asyncpraw.models.listing.generator import ListingGenerator
 from asyncpraw.models.reddit.base import RedditBase
-from asyncpraw.models.reddit.mixins import FullnameMixin
+from asyncpraw.models.reddit.mixins import CreatedMixin, FullnameMixin
 from asyncpraw.models.reddit.redditor import Redditor
 from asyncpraw.models.util import stream_generator
 from asyncpraw.util.cache import cachedproperty
@@ -264,7 +264,7 @@ class LiveContributorRelationship:
         await self.thread._reddit.post(url, data=data)
 
 
-class LiveThread(RedditBase):
+class LiveThread(CreatedMixin, RedditBase):
     """An individual :class:`.LiveThread` object.
 
     .. include:: ../../typical_attributes.rst
@@ -719,7 +719,7 @@ class LiveUpdateContribution:
         await self.update.thread._reddit.post(url, data=data)
 
 
-class LiveUpdate(FullnameMixin, RedditBase):
+class LiveUpdate(FullnameMixin, CreatedMixin, RedditBase):
     """An individual :class:`.LiveUpdate` object.
 
     .. include:: ../../typical_attributes.rst

--- a/asyncpraw/models/reddit/message.py
+++ b/asyncpraw/models/reddit/message.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from asyncpraw.const import API_PATH
 from asyncpraw.models.reddit.base import RedditBase
-from asyncpraw.models.reddit.mixins import FullnameMixin, InboxableMixin, ReplyableMixin
+from asyncpraw.models.reddit.mixins import CreatedMixin, FullnameMixin, InboxableMixin, ReplyableMixin
 from asyncpraw.models.reddit.redditor import Redditor
 from asyncpraw.models.reddit.subreddit import Subreddit
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     import asyncpraw.models
 
 
-class Message(InboxableMixin, ReplyableMixin, FullnameMixin, RedditBase):
+class Message(InboxableMixin, ReplyableMixin, FullnameMixin, CreatedMixin, RedditBase):
     """A class for private messages.
 
     .. include:: ../../typical_attributes.rst

--- a/asyncpraw/models/reddit/mixins/__init__.py
+++ b/asyncpraw/models/reddit/mixins/__init__.py
@@ -6,6 +6,7 @@ from json import dumps
 from typing import TYPE_CHECKING, Optional
 
 from asyncpraw.const import API_PATH
+from asyncpraw.models.reddit.mixins.created import CreatedMixin
 from asyncpraw.models.reddit.mixins.editable import EditableMixin
 from asyncpraw.models.reddit.mixins.fullname import FullnameMixin
 from asyncpraw.models.reddit.mixins.inboxable import InboxableMixin

--- a/asyncpraw/models/reddit/mixins/created.py
+++ b/asyncpraw/models/reddit/mixins/created.py
@@ -1,0 +1,25 @@
+"""Provide the CreatedMixin class."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+class CreatedMixin:
+    """Interface for objects that have a creation timestamp."""
+
+    #: The attribute holding the creation `Unix Time`_, in seconds. Subclasses whose
+    #: creation timestamp is stored under a different name override this.
+    _created_at_attribute = "created_utc"
+
+    @property
+    def created_datetime(self) -> datetime:
+        """Return the creation time as a timezone-aware :class:`datetime.datetime`.
+
+        The returned object is localized to the system's timezone.
+
+        """
+        return self._to_local_datetime(getattr(self, self._created_at_attribute))

--- a/asyncpraw/models/reddit/mixins/editable.py
+++ b/asyncpraw/models/reddit/mixins/editable.py
@@ -7,11 +7,25 @@ from typing import TYPE_CHECKING
 from asyncpraw.const import API_PATH
 
 if TYPE_CHECKING:  # pragma: no cover
+    from datetime import datetime
+
     import asyncpraw.models
 
 
 class EditableMixin:
     """Interface for classes that can be edited and deleted."""
+
+    @property
+    def edited_datetime(self) -> datetime | None:
+        """Return the last edit time as a timezone-aware :class:`datetime.datetime`.
+
+        Returns ``None`` if the object has never been edited. The returned object is
+        localized to the system's timezone.
+
+        """
+        if self.edited is False:
+            return None
+        return self._to_local_datetime(self.edited)
 
     async def delete(self) -> None:
         """Delete the object.

--- a/asyncpraw/models/reddit/multi.py
+++ b/asyncpraw/models/reddit/multi.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from asyncpraw.const import API_PATH
 from asyncpraw.models.listing.mixins import SubredditListingMixin
 from asyncpraw.models.reddit.base import RedditBase
+from asyncpraw.models.reddit.mixins import CreatedMixin
 from asyncpraw.models.reddit.redditor import Redditor
 from asyncpraw.models.reddit.subreddit import Subreddit, SubredditStream
 from asyncpraw.util.cache import cachedproperty
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
     import asyncpraw.models
 
 
-class Multireddit(SubredditListingMixin, RedditBase):
+class Multireddit(SubredditListingMixin, CreatedMixin, RedditBase):
     r"""A class for users' multireddits.
 
     This is referred to as a "Custom Feed" on the Reddit UI.

--- a/asyncpraw/models/reddit/poll.py
+++ b/asyncpraw/models/reddit/poll.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from asyncpraw.models.base import AsyncPRAWBase
 from asyncpraw.util import cachedproperty
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class PollOption(AsyncPRAWBase):
@@ -85,6 +88,15 @@ class PollData(AsyncPRAWBase):
         if self._user_selection is None:
             return None
         return self.option(self._user_selection)
+
+    @property
+    def voting_end_datetime(self) -> datetime:
+        """Return the poll's closing time as a timezone-aware :class:`datetime.datetime`.
+
+        The returned object is localized to the system's timezone.
+
+        """
+        return self._to_local_datetime(self.voting_end_timestamp / 1000)
 
     def __setattr__(self, attribute: str, value: Any) -> None:
         """Objectify the options attribute, and save user_selection."""

--- a/asyncpraw/models/reddit/redditor.py
+++ b/asyncpraw/models/reddit/redditor.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from asyncpraw.const import API_PATH
 from asyncpraw.models.listing.mixins import RedditorListingMixin
 from asyncpraw.models.reddit.base import RedditBase
-from asyncpraw.models.reddit.mixins import FullnameMixin, MessageableMixin
+from asyncpraw.models.reddit.mixins import CreatedMixin, FullnameMixin, MessageableMixin
 from asyncpraw.models.util import stream_generator
 from asyncpraw.util.cache import cachedproperty
 
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     import asyncpraw.models
 
 
-class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, RedditBase):
+class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, CreatedMixin, RedditBase):
     """A class representing the users of Reddit.
 
     .. include:: ../../typical_attributes.rst

--- a/asyncpraw/models/reddit/rules.py
+++ b/asyncpraw/models/reddit/rules.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 from asyncpraw.const import API_PATH
 from asyncpraw.exceptions import ClientException
 from asyncpraw.models.reddit.base import RedditBase
+from asyncpraw.models.reddit.mixins import CreatedMixin
 from asyncpraw.util import cachedproperty
 
 if TYPE_CHECKING:
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
     import asyncpraw.models
 
 
-class Rule(RedditBase):
+class Rule(CreatedMixin, RedditBase):
     """An individual :class:`.Rule` object.
 
     .. include:: ../../typical_attributes.rst

--- a/asyncpraw/models/reddit/submission.py
+++ b/asyncpraw/models/reddit/submission.py
@@ -16,7 +16,13 @@ from asyncpraw.models.comment_forest import CommentForest
 from asyncpraw.models.listing.listing import Listing
 from asyncpraw.models.listing.mixins import SubmissionListingMixin
 from asyncpraw.models.reddit.base import RedditBase
-from asyncpraw.models.reddit.mixins import FullnameMixin, ModNoteMixin, ThingModerationMixin, UserContentMixin
+from asyncpraw.models.reddit.mixins import (
+    CreatedMixin,
+    FullnameMixin,
+    ModNoteMixin,
+    ThingModerationMixin,
+    UserContentMixin,
+)
 from asyncpraw.models.reddit.poll import PollData
 from asyncpraw.models.reddit.redditor import Redditor
 from asyncpraw.models.reddit.subreddit import Subreddit
@@ -403,7 +409,7 @@ class SubmissionModeration(ThingModerationMixin, ModNoteMixin):
         )
 
 
-class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, RedditBase):
+class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, CreatedMixin, RedditBase):
     """A class for submissions to Reddit.
 
     .. include:: ../../typical_attributes.rst

--- a/asyncpraw/models/reddit/subreddit.py
+++ b/asyncpraw/models/reddit/subreddit.py
@@ -33,7 +33,7 @@ from asyncpraw.models.listing.generator import ListingGenerator
 from asyncpraw.models.listing.mixins import SubredditListingMixin
 from asyncpraw.models.reddit.base import RedditBase
 from asyncpraw.models.reddit.emoji import SubredditEmoji
-from asyncpraw.models.reddit.mixins import FullnameMixin, MessageableMixin
+from asyncpraw.models.reddit.mixins import CreatedMixin, FullnameMixin, MessageableMixin
 from asyncpraw.models.reddit.modmail import ModmailConversation
 from asyncpraw.models.reddit.removal_reasons import SubredditRemovalReasons
 from asyncpraw.models.reddit.rules import SubredditRules
@@ -2416,7 +2416,7 @@ class ModeratorRelationship(SubredditRelationship):
         await self.subreddit._reddit.post(url, data=data)
 
 
-class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBase):
+class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedMixin, RedditBase):
     """A class for Subreddits.
 
     To obtain an instance of this class for r/test execute:

--- a/tests/unit/models/test_datetime_properties.py
+++ b/tests/unit/models/test_datetime_properties.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+import pytest
+
+from asyncpraw.models import Collection, Comment, Submission
+from asyncpraw.models.mod_note import ModNote
+from asyncpraw.models.reddit.poll import PollData
+
+from .. import UnitTest
+
+
+class TestCreatedDatetime(UnitTest):
+    def test_created_datetime__from_created_at(self, reddit):
+        note = ModNote(reddit, _data={"id": "n", "created_at": 1648167599})
+        assert note.created_datetime.tzinfo is not None
+        assert note.created_datetime.timestamp() == 1648167599
+
+    def test_created_datetime__from_created_at_utc(self, reddit):
+        collection = Collection(
+            reddit,
+            _data={"collection_id": "u", "created_at_utc": 1588137147.0, "last_update_utc": 1588200000.0},
+        )
+        assert collection.created_datetime.tzinfo is not None
+        assert collection.created_datetime.timestamp() == 1588137147.0
+
+    def test_created_datetime__from_created_utc(self, reddit):
+        comment = Comment(reddit, _data={"id": "abc", "created_utc": 1588137147.0})
+        assert isinstance(comment.created_datetime, datetime)
+        assert comment.created_datetime.tzinfo is not None
+        assert comment.created_datetime.timestamp() == 1588137147.0
+
+
+class TestEditedDatetime(UnitTest):
+    def test_edited_datetime__never_edited(self, reddit):
+        comment = Comment(reddit, _data={"id": "abc", "edited": False})
+        assert comment.edited_datetime is None
+
+    def test_edited_datetime__when_edited(self, reddit):
+        submission = Submission(reddit, _data={"id": "abc", "edited": 1341972591.0})
+        assert submission.edited_datetime.tzinfo is not None
+        assert submission.edited_datetime.timestamp() == 1341972591.0
+
+
+class TestUpdatedDatetime(UnitTest):
+    def test_updated_datetime(self, reddit):
+        collection = Collection(
+            reddit,
+            _data={"collection_id": "u", "created_at_utc": 1588137147.0, "last_update_utc": 1588200000.0},
+        )
+        assert collection.updated_datetime.tzinfo is not None
+        assert collection.updated_datetime.timestamp() == 1588200000.0
+
+
+class TestVotingEndDatetime(UnitTest):
+    def test_voting_end_datetime__converts_milliseconds(self, reddit):
+        poll_data = PollData(reddit, _data={"voting_end_timestamp": 1588309947690})
+        assert poll_data.voting_end_datetime.tzinfo is not None
+        assert poll_data.voting_end_datetime.timestamp() == pytest.approx(1588309947.69)


### PR DESCRIPTION
## Summary

Mirrors praw-dev/praw#2124 (commit `34d13441`) in Async PRAW. Reddit returns timestamps as raw Unix-time numbers (e.g. `created_utc`, `voting_end_timestamp`). This exposes normalized, timezone-aware `datetime` companions without altering the raw fields:

- **`CreatedMixin.created_datetime`** — sourced from `created_utc` by default, overridable via `_created_at_attribute` (`created_at_utc` for `Collection`, `created_at` for `ModNote`). Wired into `Comment`, `Submission`, `Redditor`, `Subreddit`, `Message`, `Multireddit`, `Rule`, `LiveThread`, `LiveUpdate`, `Collection`, and `ModNote`.
- **`Collection.updated_datetime`**, **`PollData.voting_end_datetime`** (converting the millisecond value), and **`EditableMixin.edited_datetime`** (`None` when the object has not been edited).
- **`AsyncPRAWBase._to_local_datetime`** centralizes the conversion to a system-local, timezone-aware `datetime`.

The properties are synchronous (pure timestamp conversion), so no `await` is required.

## Testing

- New `tests/unit/models/test_datetime_properties.py` covering each property (created from `created_utc`/`created_at_utc`/`created_at`, edited/never-edited, updated, and millisecond voting-end conversion).
- Full suite: 962 passed, 1 skipped, **100% coverage** (`coverage run --source asyncpraw`).