### PR TITLE
Warn on praw.ini endpoint overrides in the working directory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,10 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
   ``stream`` methods) that is invoked with any exception raised while fetching items,
   allowing the stream to resume rather than terminate. Re-raise from the handler to stop
   the stream.
+- Warn when a ``praw.ini`` in the current working directory sets the ``oauth_url`` or
+  ``reddit_url`` endpoint, as such a file can redirect credentials to an untrusted host.
+  The warning can be silenced by setting the ``PRAW_ALLOW_ENDPOINT_OVERRIDE``
+  environment variable.
 - :meth:`.Redditor.overview` to iterate over a Redditor's combined comments and
   submissions, mirroring the user overview page on Reddit.
 - Add support for Python 3.13.

--- a/asyncpraw/config.py
+++ b/asyncpraw/config.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from threading import Lock
 from types import MappingProxyType
 from typing import Any
+from warnings import warn
 
 from asyncpraw.exceptions import ClientException
 
@@ -66,8 +67,45 @@ class Config:
         if os_config_path is not None:
             locations.insert(0, str(os_config_path / "praw.ini"))
 
+        cls._warn_on_endpoint_override(interpolator_class)
         config.read(locations)
         cls.CONFIG = config
+
+    @staticmethod
+    def _warn_on_endpoint_override(interpolator_class: configparser.Interpolation | None) -> None:
+        """Warn if a ``praw.ini`` in the current directory overrides OAuth endpoints.
+
+        ``praw.ini`` is loaded from the current working directory, so a file planted
+        there can redirect ``oauth_url`` or ``reddit_url`` to an attacker-controlled
+        host and capture credentials. Legitimate configs almost never set these keys, so
+        surface a warning when they do.
+
+        The warning can be silenced by setting the ``PRAW_ALLOW_ENDPOINT_OVERRIDE``
+        environment variable. It is intentionally not a ``praw.ini`` option, as that
+        would let the planted file silence its own warning.
+
+        """
+        if os.getenv("PRAW_ALLOW_ENDPOINT_OVERRIDE"):
+            return
+        cwd_config_path = Path("praw.ini")
+        if not cwd_config_path.is_file():
+            return
+        cwd_config = configparser.ConfigParser(interpolation=interpolator_class)
+        try:
+            cwd_config.read(str(cwd_config_path))
+        except configparser.Error:
+            return  # A malformed file will be reported by the subsequent read.
+        keys_present = set(cwd_config.defaults())
+        for section in cwd_config.sections():
+            keys_present.update(cwd_config.options(section))
+        if overridden := sorted({"oauth_url", "reddit_url"} & keys_present):
+            warn(
+                f"The praw.ini in the current working directory ({cwd_config_path.resolve()})"
+                f" overrides the {' and '.join(overridden)} endpoint(s). Credentials will be"
+                " sent to the configured host. Remove this file or these keys if it is not"
+                " trusted.",
+                stacklevel=4,
+            )
 
     @property
     def short_url(self) -> str:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 from pathlib import Path
 
 import pytest
@@ -146,3 +147,54 @@ class TestConfigInterpolation:
             config = Config("INTERPOLATION")
             assert config.custom["basic_interpolation"] == "%(reddit_url)s"
             assert config.custom["extended_interpolation"] == "${reddit_url}"
+
+
+class TestConfigEndpointOverrideWarning:
+    @staticmethod
+    def _write_cwd_ini(tmp_path, monkeypatch, contents):
+        (tmp_path / "praw.ini").write_text(contents)
+        monkeypatch.chdir(tmp_path)
+
+    def test_both_endpoints_override(self, tmp_path, monkeypatch):
+        self._write_cwd_ini(
+            tmp_path,
+            monkeypatch,
+            "[bot]\noauth_url = https://evil.example\nreddit_url = https://evil.example\n",
+        )
+        with pytest.warns(UserWarning, match="oauth_url and reddit_url"):
+            Config._warn_on_endpoint_override(None)
+
+    def test_malformed_cwd_ini_is_ignored(self, tmp_path, monkeypatch):
+        self._write_cwd_ini(tmp_path, monkeypatch, "not a valid ini file")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Config._warn_on_endpoint_override(None)
+
+    def test_no_cwd_ini(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Config._warn_on_endpoint_override(None)
+
+    def test_no_override(self, tmp_path, monkeypatch):
+        self._write_cwd_ini(tmp_path, monkeypatch, "[bot]\nclient_id = abc\n")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Config._warn_on_endpoint_override(None)
+
+    def test_oauth_url_override(self, tmp_path, monkeypatch):
+        self._write_cwd_ini(tmp_path, monkeypatch, "[bot]\noauth_url = https://evil.example\n")
+        with pytest.warns(UserWarning, match="oauth_url"):
+            Config._warn_on_endpoint_override(None)
+
+    def test_override_suppressed_by_env_var(self, tmp_path, monkeypatch):
+        self._write_cwd_ini(tmp_path, monkeypatch, "[bot]\noauth_url = https://evil.example\n")
+        monkeypatch.setenv("PRAW_ALLOW_ENDPOINT_OVERRIDE", "1")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            Config._warn_on_endpoint_override(None)
+
+    def test_reddit_url_override_in_default_section(self, tmp_path, monkeypatch):
+        self._write_cwd_ini(tmp_path, monkeypatch, "[DEFAULT]\nreddit_url = https://evil.example\n")
+        with pytest.warns(UserWarning, match="reddit_url"):
+            Config._warn_on_endpoint_override(None)


### PR DESCRIPTION
## Summary

Mirrors praw-dev/praw's config hardening in Async PRAW. `praw.ini` is loaded from the current working directory, so a file planted there can redirect `oauth_url` or `reddit_url` to an attacker-controlled host and capture credentials. This warns when a working-directory `praw.ini` sets either endpoint.

The warning can be silenced by setting the `PRAW_ALLOW_ENDPOINT_OVERRIDE` environment variable — matching the `praw_`-prefixed environment namespace Async PRAW already uses for all configuration (e.g. `praw_client_id`). It is intentionally **not** a `praw.ini` option, so a planted file cannot silence its own warning.

## Testing

- New `TestConfigEndpointOverrideWarning` covering both-endpoint, single-endpoint, `[DEFAULT]`-section, no-override, no-file, malformed-file, and env-var-suppression cases.
- Full suite: 969 passed, 1 skipped, **100% coverage** (`coverage run --source asyncpraw`).