### PR TITLE
Document that fetch-controlling attributes must be set before fetch

### DIFF
--- a/docs/package_info/asyncpraw_migration.rst
+++ b/docs/package_info/asyncpraw_migration.rst
@@ -107,6 +107,12 @@ you need to call the ``.load()`` method first:
     # network request is not made as object is already fully fetched
     print(submission.score)
 
+Because a :class:`.Submission` is fetched on initialization, its ``comment_sort`` and
+``comment_limit`` attributes -- and :meth:`.Submission.add_fetch_param` -- must be set
+before it is fetched. Initialize the submission with ``fetch=False``, set them, then
+call ``load()``. Setting any of them after the submission is fetched raises
+:class:`.ClientException`.
+
 **************************
  Getting items by Indices
 **************************


### PR DESCRIPTION
## Summary

Follow-up to #351. Adds a note to the **Lazy Loading** section of the migration guide explaining that, because Async PRAW fetches a `Submission` on initialization, the fetch-controlling settings must be set *before* the fetch:

- `comment_sort` / `comment_limit` attributes
- `Submission.add_fetch_param`

The pattern is `await reddit.submission(id, fetch=False)` → set them → `await submission.load()`. Setting any of them after the submission is fetched raises `ClientException` (the behavior introduced in #351).

This is the natural home for the note since the Lazy Loading section already explains the eager-fetch-by-default / `fetch=False` distinction.