### PR TITLE
Centralize media uploads and merge submit methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,9 +69,16 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
   body text to accompany the link submission. An exception is raised when trying to use
   ``inline_media`` with ``selftext`` for a ``url`` submission because Reddit does not
   support inline media in body text for link submissions.
-- :meth:`.Subreddit.submit_video`, :meth:`.Subreddit.submit_gallery`, and
-  :meth:`.Subreddit.submit_image` now accept an optional Markdown-formatted ``selftext``
-  parameter.
+- ``Subreddit.submit_gallery``, ``Subreddit.submit_image``, ``Subreddit.submit_poll``,
+  and ``Subreddit.submit_video`` have been merged into :meth:`.Subreddit.submit`. The
+  kind of submission is selected with the ``gallery``, ``image``, ``poll``, ``url``, or
+  ``video`` keyword argument. At least one of those, or ``selftext``, must be provided,
+  and they are mutually exclusive, while ``selftext`` may accompany any of them as
+  optional Markdown-formatted body text. ``image`` takes a :class:`.PostMedia` instance;
+  ``gallery`` takes a list of :class:`.PostMedia` instances or ``dict``\ s with a
+  ``media`` key; ``video`` takes a :class:`.PostMedia` instance or a ``dict`` with a
+  ``media`` key and optional ``gif`` and ``thumbnail`` keys; and ``poll`` takes a
+  ``dict`` with ``duration`` and ``options`` keys.
 - Media upload methods now accept :class:`.Media` instances instead of file paths:
 
   - The ``image_path`` argument to :meth:`.SubredditEmoji.add` has been replaced by
@@ -460,7 +467,7 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
 **Added**
 
 - Add method :meth:`.Subreddits.premium` to reflect the naming change in Reddit's API.
-- Ability to submit image galleries with :meth:`~.Subreddit.submit_gallery`.
+- Ability to submit image galleries with ``Subreddit.submit_gallery``.
 - Ability to pass a gallery url to :meth:`.Reddit.submission`.
 - Ability to specify modmail mute duration.
 - Add method :meth:`.invited` to get invited moderators of a subreddit.
@@ -477,9 +484,9 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
 
 - :class:`.BoundedSet` will now utilize a Last-Recently-Used (LRU) storing mechanism,
   which will change the order in which elements are removed from the set.
-- Improved :meth:`~.Subreddit.submit_image` and :meth:`~.Subreddit.submit_video`
-  performance in slow network environments by removing a race condition when
-  establishing a websocket connection.
+- Improved ``Subreddit.submit_image`` and ``Subreddit.submit_video`` performance in slow
+  network environments by removing a race condition when establishing a websocket
+  connection.
 
 **Deprecated**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,11 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
 - Add support for Python 3.14.
 - Add support for optional Markdown-formatted ``selftext`` when submitting link, image,
   gallery and video posts.
+- Add :class:`.Media` and its subclasses :class:`.EmojiMedia`, :class:`.PostMedia`,
+  :class:`.StylesheetAsset`, :class:`.StylesheetImage`, and :class:`.WidgetMedia` to
+  consolidate media uploads. Media can be constructed from a file path, or from
+  ``bytes`` content along with a ``name``, so media no longer has to be written to disk
+  before uploading.
 - Support delayed session creation in asyncprawcore 2.5.0+.
 - Add parameter ``fetch`` to :meth:`.get_rule` to control whether to fetch the rule data
   when initializing the rule object.
@@ -67,6 +72,33 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
 - :meth:`.Subreddit.submit_video`, :meth:`.Subreddit.submit_gallery`, and
   :meth:`.Subreddit.submit_image` now accept an optional Markdown-formatted ``selftext``
   parameter.
+- Media upload methods now accept :class:`.Media` instances instead of file paths:
+
+  - The ``image_path`` argument to :meth:`.SubredditEmoji.add` has been replaced by
+    ``media``, which takes an :class:`.EmojiMedia` instance.
+  - The ``image_path`` arguments to the :class:`.SubredditStylesheet` ``upload_*``
+    methods have been replaced by ``media``, which must be passed positionally.
+    :meth:`.SubredditStylesheet.upload`, :meth:`.SubredditStylesheet.upload_header`,
+    :meth:`.SubredditStylesheet.upload_mobile_header`, and
+    :meth:`.SubredditStylesheet.upload_mobile_icon` take a :class:`.StylesheetImage`
+    instance, while :meth:`.SubredditStylesheet.upload_banner`,
+    :meth:`.SubredditStylesheet.upload_banner_additional_image`,
+    :meth:`.SubredditStylesheet.upload_banner_hover_image`, and
+    :meth:`.SubredditStylesheet.upload_mobile_banner` take a :class:`.StylesheetAsset`
+    instance.
+  - The ``file_path`` argument to :meth:`.SubredditWidgetsModeration.upload_image` has
+    been replaced by ``media``, which takes a :class:`.WidgetMedia` instance and must be
+    passed positionally.
+  - The ``path`` argument to :class:`.InlineMedia` (:class:`.InlineGif`,
+    :class:`.InlineImage`, and :class:`.InlineVideo`) has been replaced by ``media``,
+    which takes a :class:`.PostMedia` instance.
+
+- An unknown media type now raises :class:`.ClientException` when uploading media,
+  instead of falling back to JPEG.
+- Media uploads to Reddit's S3 buckets now respect the configured ``timeout`` and raise
+  ``asyncprawcore.RequestException`` on transport errors, consistent with all other
+  requests, instead of bypassing the configured timeout and raising raw ``aiohttp``
+  exceptions.
 - :meth:`.CommentForest.list` no longer needs to be awaited.
 - The keyword argument ``lazy`` has been replace by ``fetch`` to consolidate the keyword
   argument used to explicitly perform a fetch when initializing an object.

--- a/asyncpraw/models/__init__.py
+++ b/asyncpraw/models/__init__.py
@@ -11,6 +11,7 @@ from asyncpraw.models.list.trophy import TrophyList
 from asyncpraw.models.listing.domain import DomainListing
 from asyncpraw.models.listing.generator import ListingGenerator
 from asyncpraw.models.listing.listing import Listing, ModeratorListing, ModmailConversationsListing
+from asyncpraw.models.media import EmojiMedia, Media, PostMedia, StylesheetAsset, StylesheetImage, WidgetMedia
 from asyncpraw.models.mod_action import ModAction
 from asyncpraw.models.mod_note import ModNote
 from asyncpraw.models.mod_notes import RedditModNotes, RedditorModNotes, SubredditModNotes

--- a/asyncpraw/models/media.py
+++ b/asyncpraw/models/media.py
@@ -1,0 +1,291 @@
+"""Provide classes for uploading media to Reddit."""
+
+from __future__ import annotations
+
+import sys
+from io import BytesIO
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, cast
+
+import aiofiles
+from asyncprawcore.exceptions import ServerError
+from defusedxml import ElementTree
+
+from asyncpraw.const import API_PATH, JPEG_HEADER
+from asyncpraw.exceptions import (
+    ClientException,
+    RedditAPIException,
+    RedditErrorItem,
+    TooLargeMediaException,
+)
+
+if sys.version_info >= (3, 13):  # pragma: no cover
+    from mimetypes import guess_file_type
+else:  # pragma: no cover
+    from mimetypes import guess_type as guess_file_type
+
+if TYPE_CHECKING:
+    from aiohttp import ClientResponse
+
+    import asyncpraw
+    from asyncpraw import models
+
+
+class Media:
+    """Base class representing media that can be uploaded to Reddit.
+
+    Use one of the subclasses, e.g., :class:`.EmojiMedia` or :class:`.PostMedia`,
+    depending on what the media is being uploaded for.
+
+    """
+
+    LEASE_API_PATH: ClassVar[str]
+    LEASE_RESPONSE_KEY: ClassVar[str] = "s3UploadLease"
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether the other instance equals the current."""
+        return type(other) is type(self) and self.name == other.name and self._fp == other._fp
+
+    def __hash__(self) -> int:
+        """Return the hash of the current instance."""
+        return hash((self.__class__.__name__, self.name, self._fp))
+
+    def __init__(self, fp: str | bytes, /, name: str | None = None) -> None:
+        """Initialize a :class:`.Media` instance.
+
+        :param fp: The path to a media file as a string, or the content of a media file
+            as a :class:`bytes` object.
+        :param name: The name of the media file, e.g., ``"picture.png"``. The name is
+            used to infer the media's MIME type. When ``fp`` is a path the name is
+            derived from it, otherwise this parameter is required.
+
+        """
+        if isinstance(fp, bytes):
+            if not name:
+                msg = "'name' is required when 'fp' is a bytes object."
+                raise ValueError(msg)
+            stored: Path | bytes = fp
+        else:
+            path = Path(fp)
+            name = name or path.name
+            stored = path
+        self._fp = stored
+        self.name = name
+        self._mime_type_value: str | None = None
+
+    def __repr__(self) -> str:
+        """Return a string representation of the instance."""
+        return f"<{self.__class__.__name__} name={self.name!r}>"
+
+    @property
+    def _mime_type(self) -> str:
+        if self._mime_type_value is None:
+            mime_type, _ = guess_file_type(self.name)
+            if mime_type is None:
+                msg = f"Unable to determine the MIME type of {self.name!r}."
+                raise ClientException(msg)
+            self._mime_type_value = mime_type
+        return self._mime_type_value
+
+    async def _build_payload(self) -> BytesIO:
+        """Read the media content and wrap it in a named file-like object."""
+        if isinstance(self._fp, bytes):
+            data = self._fp
+        else:
+            async with aiofiles.open(self._fp, "rb") as file:
+                data = await file.read()
+        payload = BytesIO(data)
+        payload.name = self.name
+        return payload
+
+    def _build_lease_data(self, **additional_data: str) -> dict[str, str]:
+        return {"filepath": self.name, "mimetype": self._mime_type, **additional_data}
+
+    async def _lease_and_post(
+        self, lease_url: str, reddit: asyncpraw.Reddit, /, **additional_lease_data: str
+    ) -> tuple[dict[str, Any], dict[str, str], str]:
+        lease_data = self._build_lease_data(**additional_lease_data)
+        lease_response, upload_data, upload_url = await self._obtain_lease(lease_data, lease_url, reddit)
+        await self._post_to_s3(reddit, upload_data, upload_url)
+        return lease_response, upload_data, upload_url
+
+    async def _obtain_lease(
+        self, lease_data: dict[str, str], lease_url: str, reddit: asyncpraw.Reddit, /
+    ) -> tuple[dict[str, Any], dict[str, str], str]:
+        lease_response = await reddit.post(lease_url, data=lease_data)
+        upload_lease = lease_response[self.LEASE_RESPONSE_KEY]
+        upload_data = {item["name"]: item["value"] for item in upload_lease["fields"]}
+        upload_url = f"https:{upload_lease['action']}"
+        return lease_response, upload_data, upload_url
+
+    async def _post_to_s3(self, reddit: asyncpraw.Reddit, upload_data: dict[str, str], upload_url: str, /) -> None:
+        assert reddit._core is not None
+        data: dict[str, Any] = {**upload_data, "file": await self._build_payload()}
+        async with reddit._core.requestor.request("POST", upload_url, data=data) as response:
+            if not response.ok:
+                await self._raise_upload_error(response)
+
+    @staticmethod
+    async def _raise_upload_error(response: ClientResponse, /) -> None:
+        raise ServerError(response=response)
+
+    async def _upload(self, subreddit: models.Subreddit, /, **additional_lease_data: str) -> str:
+        """Upload the media to Reddit.
+
+        :param subreddit: The subreddit the media is associated with.
+        :param additional_lease_data: Additional data to include in the upload lease
+            request.
+
+        :returns: The URL of the uploaded media.
+
+        """
+        lease_url = self.LEASE_API_PATH.format(subreddit=subreddit)
+        _, upload_data, upload_url = await self._lease_and_post(lease_url, subreddit._reddit, **additional_lease_data)
+        return f"{upload_url}/{upload_data['key']}"
+
+
+class EmojiMedia(Media):
+    """Media to be uploaded as a subreddit emoji.
+
+    See :meth:`.SubredditEmoji.add`.
+
+    """
+
+    LEASE_API_PATH = API_PATH["emoji_lease"]
+
+    async def _upload(self, subreddit: models.Subreddit, /, **additional_lease_data: str) -> str:
+        """Upload the media to Reddit.
+
+        :param subreddit: The subreddit the emoji is associated with.
+        :param additional_lease_data: Additional data to include in the upload lease
+            request.
+
+        :returns: The S3 key of the uploaded media.
+
+        """
+        lease_url = self.LEASE_API_PATH.format(subreddit=subreddit)
+        _, upload_data, _ = await self._lease_and_post(lease_url, subreddit._reddit, **additional_lease_data)
+        return upload_data["key"]
+
+
+class PostMedia(Media):
+    """Media to be uploaded as part of a submission.
+
+    See :meth:`.Subreddit.submit` and :class:`.InlineMedia`.
+
+    """
+
+    LEASE_API_PATH = API_PATH["media_asset"]
+    LEASE_RESPONSE_KEY = "args"
+
+    @staticmethod
+    async def _parse_xml_response(response: ClientResponse, /) -> None:
+        """Parse the XML from a response and raise any errors found."""
+        root = ElementTree.fromstring(await response.text())
+        tags = [element.tag for element in root]
+        if tags[:4] == ["Code", "Message", "ProposedSize", "MaxSizeAllowed"]:
+            # Returned if media is too big
+            *_, actual, maximum_size = (element.text for element in root[:4])
+            raise TooLargeMediaException(actual=int(actual or 0), maximum_size=int(maximum_size or 0))
+
+    @staticmethod
+    async def _raise_upload_error(response: ClientResponse, /) -> None:
+        await PostMedia._parse_xml_response(response)
+        await Media._raise_upload_error(response)
+
+    async def _upload(  # pyright: ignore[reportIncompatibleMethodOverride]  # post media is uploaded with a Reddit instance rather than a Subreddit
+        self, reddit: asyncpraw.Reddit, /, *, expected_mime_prefix: str | None = None, upload_type: str = "link"
+    ) -> str:
+        """Upload the media to Reddit (undocumented endpoint).
+
+        Unlike the other :class:`.Media` subclasses, post media is not associated with a
+        subreddit when uploaded, so this method takes a :class:`.Reddit` instance.
+
+        :param reddit: The :class:`.Reddit` instance to upload with.
+        :param expected_mime_prefix: If provided, enforce that the media has a MIME type
+            that starts with the provided prefix.
+        :param upload_type: One of ``"link"``, ``"gallery"``, or ``"selfpost"``
+            (default: ``"link"``).
+
+        :returns: The URL of the uploaded media when ``upload_type`` is ``"link"``,
+            otherwise the media's asset ID.
+
+        """
+        if expected_mime_prefix is not None and self._mime_type.partition("/")[0] != expected_mime_prefix:
+            msg = f"Expected a mimetype starting with {expected_mime_prefix!r} but got mimetype {self._mime_type!r} (from file name {self.name!r})."
+            raise ClientException(msg)
+        lease_response, upload_data, upload_url = await self._lease_and_post(self.LEASE_API_PATH, reddit)
+        if upload_type == "link":
+            return f"{upload_url}/{upload_data['key']}"
+        return lease_response["asset"]["asset_id"]
+
+
+class StylesheetAsset(Media):
+    """Media to be uploaded as a subreddit style asset, e.g., a banner.
+
+    See :meth:`.SubredditStylesheet.upload_banner`.
+
+    """
+
+    LEASE_API_PATH = API_PATH["style_asset_lease"]
+
+    async def _upload(  # pyright: ignore[reportIncompatibleMethodOverride]  # style assets require an image_type rather than arbitrary lease data
+        self, subreddit: models.Subreddit, /, *, image_type: str
+    ) -> str:
+        """Upload the media to Reddit.
+
+        :param subreddit: The subreddit the style asset is associated with.
+        :param image_type: The type of style asset, e.g., ``"bannerBackgroundImage"``.
+
+        :returns: The URL of the uploaded media.
+
+        """
+        return await super()._upload(subreddit, imagetype=image_type)
+
+
+class StylesheetImage(Media):
+    """Media to be uploaded as a subreddit stylesheet image.
+
+    See :meth:`.SubredditStylesheet.upload`.
+
+    """
+
+    UPLOAD_API_PATH = API_PATH["upload_image"]
+
+    async def _upload(  # pyright: ignore[reportIncompatibleMethodOverride]  # stylesheet image upload returns the raw response dict
+        self, subreddit: models.Subreddit, /, **additional_data: str
+    ) -> dict[str, Any]:
+        """Upload the media to Reddit.
+
+        :param subreddit: The subreddit the stylesheet image is associated with.
+        :param additional_data: Additional data to include in the upload request.
+
+        :returns: A dictionary containing a link to the uploaded image under the key
+            ``img_src``.
+
+        """
+        payload = await self._build_payload()
+        image_type = "jpg" if payload.getvalue().startswith(JPEG_HEADER) else "png"
+        data = {"img_type": image_type, **additional_data}
+        url = self.UPLOAD_API_PATH.format(subreddit=subreddit)
+        files = cast("dict[str, Any]", {"file": payload})
+        response = await subreddit._reddit.post(url, data=data, files=files)
+        if response["errors"]:
+            error_type = response["errors"][0]
+            error_value = response.get("errors_values", [""])[0]
+            assert error_type in {
+                "BAD_CSS_NAME",
+                "IMAGE_ERROR",
+            }, "Please file a bug with Async PRAW."
+            raise RedditAPIException([RedditErrorItem(error_type=error_type, message=error_value or "", field="")])
+        return response
+
+
+class WidgetMedia(Media):
+    """Media to be uploaded for use in a subreddit widget.
+
+    See :meth:`.SubredditWidgetsModeration.upload_image`.
+
+    """
+
+    LEASE_API_PATH = API_PATH["widget_lease"]

--- a/asyncpraw/models/reddit/draft.py
+++ b/asyncpraw/models/reddit/draft.py
@@ -190,12 +190,7 @@ class Draft(RedditBase):
 
         .. seealso::
 
-            - :meth:`~.Subreddit.submit` to submit url posts and selftexts
-            - :meth:`~.Subreddit.submit_gallery`. to submit more than one image in the
-              same post
-            - :meth:`~.Subreddit.submit_image` to submit images
-            - :meth:`~.Subreddit.submit_poll` to submit polls
-            - :meth:`~.Subreddit.submit_video` to submit videos and videogifs
+            :meth:`~.Subreddit.submit` to make a submission directly.
 
         """
         submit_kwargs["draft_id"] = self.id

--- a/asyncpraw/models/reddit/emoji.py
+++ b/asyncpraw/models/reddit/emoji.py
@@ -2,11 +2,7 @@
 
 from __future__ import annotations
 
-from io import BytesIO
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
-
-import aiofiles
 
 from asyncpraw.const import API_PATH
 from asyncpraw.exceptions import ClientException
@@ -174,7 +170,7 @@ class SubredditEmoji:
     async def add(
         self,
         *,
-        image_path: str,
+        media: asyncpraw.models.EmojiMedia,
         mod_flair_only: bool | None = None,
         name: str,
         post_flair_allowed: bool | None = None,
@@ -182,7 +178,7 @@ class SubredditEmoji:
     ) -> Emoji:
         """Add an emoji to this subreddit.
 
-        :param image_path: A path to a jpeg or png image.
+        :param media: The :class:`.EmojiMedia` to be uploaded as an emoji.
         :param mod_flair_only: When provided, indicate whether the emoji is restricted
             to mod use only (default: ``None``).
         :param name: The name of the emoji.
@@ -197,38 +193,20 @@ class SubredditEmoji:
 
         .. code-block:: python
 
+            from asyncpraw.models import EmojiMedia
+
+            media = EmojiMedia("emoji.png")
             subreddit = await reddit.subreddit("test")
-            await subreddit.emoji.add(name="emoji", image_path="emoji.png")
+            await subreddit.emoji.add(media=media, name="emoji")
 
         """
-        file = Path(image_path)
-        data = {
-            "filepath": file.name,
-            "mimetype": "image/jpeg",
-        }
-        if image_path.lower().endswith(".png"):
-            data["mimetype"] = "image/png"
-        url = API_PATH["emoji_lease"].format(subreddit=self.subreddit)
-
-        # until we learn otherwise, assume this request always succeeds
-        response = await self._reddit.post(url, data=data)
-        upload_lease = response["s3UploadLease"]
-        upload_data = {item["name"]: item["value"] for item in upload_lease["fields"]}
-        upload_url = f"https:{upload_lease['action']}"
-
-        assert self._reddit._core is not None
-        async with aiofiles.open(file, "rb") as image:
-            upload = BytesIO(await image.read())
-        upload.name = file.name
-        upload_data["file"] = upload
-        async with self._reddit._core.requestor.request("POST", upload_url, data=upload_data) as response:
-            response.raise_for_status()
+        s3_key = await media._upload(self.subreddit)
 
         data = {
             "mod_flair_only": mod_flair_only,
             "name": name,
             "post_flair_allowed": post_flair_allowed,
-            "s3_key": upload_data["key"],
+            "s3_key": s3_key,
             "user_flair_allowed": user_flair_allowed,
         }
         url = API_PATH["emoji_upload"].format(subreddit=self.subreddit)

--- a/asyncpraw/models/reddit/inline_media.py
+++ b/asyncpraw/models/reddit/inline_media.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from asyncpraw import models
+
 
 class InlineMedia:
     """Provides a way to embed media in self posts."""
@@ -10,22 +15,22 @@ class InlineMedia:
 
     def __eq__(self, other: object) -> bool:
         """Return whether the other instance equals the current."""
-        return all(getattr(self, attr) == getattr(other, attr) for attr in ["TYPE", "path", "caption", "media_id"])
+        return all(getattr(self, attr) == getattr(other, attr) for attr in ["TYPE", "media", "caption", "media_id"])
 
     def __hash__(self) -> int:
         """Return the hash of the current instance."""
         return hash(self.__class__.__name__) ^ hash(
-            tuple(getattr(self, attr) for attr in ["TYPE", "path", "caption", "media_id"])
+            tuple(getattr(self, attr) for attr in ["TYPE", "media", "caption", "media_id"])
         )
 
-    def __init__(self, *, caption: str | None = None, path: str) -> None:
+    def __init__(self, *, caption: str | None = None, media: models.PostMedia) -> None:
         """Initialize an :class:`.InlineMedia` instance.
 
         :param caption: An optional caption to add to the image (default: ``None``).
-        :param path: The path to a media file.
+        :param media: The :class:`.PostMedia` to embed.
 
         """
-        self.path = path
+        self.media = media
         self.caption = caption
         self.media_id: str | None = None
 

--- a/asyncpraw/models/reddit/subreddit.py
+++ b/asyncpraw/models/reddit/subreddit.py
@@ -4,34 +4,27 @@ from __future__ import annotations
 
 import contextlib
 from asyncio import TimeoutError as AsyncTimeoutError
-from contextlib import asynccontextmanager
 from copy import deepcopy
 from csv import writer
-from io import BytesIO, StringIO
+from io import StringIO
 from json import dumps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urljoin
 
-import aiofiles
 from aiohttp import WebSocketError
-from aiohttp.http_exceptions import HttpProcessingError
 from asyncprawcore import Redirect
-from asyncprawcore.exceptions import ServerError
-from defusedxml import ElementTree
 
-from asyncpraw.const import API_PATH, JPEG_HEADER
+from asyncpraw.const import API_PATH
 from asyncpraw.exceptions import (
-    ClientException,
     InvalidFlairTemplateID,
     MediaPostFailed,
     RedditAPIException,
-    RedditErrorItem,
-    TooLargeMediaException,
     WebSocketException,
 )
 from asyncpraw.models.listing.generator import ListingGenerator
 from asyncpraw.models.listing.mixins import SubredditListingMixin
+from asyncpraw.models.media import PostMedia
 from asyncpraw.models.reddit.base import RedditBase
 from asyncpraw.models.reddit.emoji import SubredditEmoji
 from asyncpraw.models.reddit.mixins import CreatedMixin, FullnameMixin, MessageableMixin
@@ -45,8 +38,6 @@ from asyncpraw.util import cachedproperty
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator, Iterator, Sequence
-
-    from aiohttp import ClientResponse
 
     import asyncpraw.models
     from asyncpraw.models.reddit.collections import SubredditCollections
@@ -1603,50 +1594,6 @@ class SubredditStylesheet:
         url = API_PATH["structured_styles"].format(subreddit=self.subreddit)
         await self.subreddit._reddit.patch(url, data=style_data)
 
-    async def _upload_image(self, *, data: dict[str, str | Any], image_path: str) -> dict[str, Any]:
-        file = Path(image_path)
-        async with aiofiles.open(file, "rb") as image:
-            content = await image.read()
-        data["img_type"] = "jpg" if content[: len(JPEG_HEADER)] == JPEG_HEADER else "png"
-        upload = BytesIO(content)
-        upload.name = file.name
-        url = API_PATH["upload_image"].format(subreddit=self.subreddit)
-        response = await self.subreddit._reddit.post(url, data=data, files={"file": upload})
-        if response["errors"]:
-            error_type = response["errors"][0]
-            error_value = response.get("errors_values", [""])[0]
-            assert error_type in {
-                "BAD_CSS_NAME",
-                "IMAGE_ERROR",
-            }, "Please file a bug with Async PRAW."
-            raise RedditAPIException(cast("list[RedditErrorItem | list[str] | str]", [[error_type, error_value, None]]))
-        return response
-
-    async def _upload_style_asset(self, *, image_path: str, image_type: str) -> str:
-        file = Path(image_path)
-        data = {"imagetype": image_type, "filepath": file.name}
-        data["mimetype"] = "image/jpeg"
-        if image_path.lower().endswith(".png"):
-            data["mimetype"] = "image/png"
-        url = API_PATH["style_asset_lease"].format(subreddit=self.subreddit)
-
-        response = await self.subreddit._reddit.post(url, data=data)
-        upload_lease = response["s3UploadLease"]
-        upload_data = {item["name"]: item["value"] for item in upload_lease["fields"]}
-        upload_url = f"https:{upload_lease['action']}"
-
-        assert self.subreddit._reddit._core is not None
-        requestor = self.subreddit._reddit._core.requestor
-        assert requestor._http is not None
-        async with aiofiles.open(file, "rb") as image:
-            upload = BytesIO(await image.read())
-        upload.name = file.name
-        upload_data["file"] = upload
-        response = await requestor._http.post(upload_url, data=upload_data)
-        response.raise_for_status()
-
-        return f"{upload_url}/{upload_data['key']}"
-
     async def delete_banner(self) -> None:
         """Remove the current :class:`.Subreddit` (redesign) banner image.
 
@@ -1794,10 +1741,10 @@ class SubredditStylesheet:
         url = API_PATH["subreddit_stylesheet"].format(subreddit=self.subreddit)
         await self.subreddit._reddit.post(url, data=data)
 
-    async def upload(self, *, image_path: str, name: str) -> dict[str, str]:
+    async def upload(self, media: asyncpraw.models.StylesheetImage, /, *, name: str) -> dict[str, str]:
         """Upload an image to the :class:`.Subreddit`.
 
-        :param image_path: A path to a jpeg or png image.
+        :param media: The :class:`.StylesheetImage` to upload.
         :param name: The name to use for the image. If an image already exists with the
             same name, it will be replaced.
 
@@ -1814,16 +1761,18 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
+            from asyncpraw.models import StylesheetImage
+
             subreddit = await reddit.subreddit("test")
-            await subreddit.stylesheet.upload(name="smile", image_path="img.png")
+            await subreddit.stylesheet.upload(StylesheetImage("img.png"), name="smile")
 
         """
-        return await self._upload_image(data={"name": name, "upload_type": "img"}, image_path=image_path)
+        return await media._upload(self.subreddit, name=name, upload_type="img")
 
-    async def upload_banner(self, image_path: str) -> None:
+    async def upload_banner(self, media: asyncpraw.models.StylesheetAsset, /) -> None:
         """Upload an image for the :class:`.Subreddit`'s (redesign) banner image.
 
-        :param image_path: A path to a jpeg or png image.
+        :param media: The :class:`.StylesheetAsset` to upload.
 
         :raises: ``asyncprawcore.TooLarge`` if the overall request body is too large.
         :raises: :class:`.RedditAPIException` if there are other issues with the
@@ -1835,23 +1784,26 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
+            from asyncpraw.models import StylesheetAsset
+
             subreddit = await reddit.subreddit("test")
-            await subreddit.stylesheet.upload_banner("banner.png")
+            await subreddit.stylesheet.upload_banner(StylesheetAsset("banner.png"))
 
         """
         image_type = "bannerBackgroundImage"
-        image_url = await self._upload_style_asset(image_path=image_path, image_type=image_type)
+        image_url = await media._upload(self.subreddit, image_type=image_type)
         await self._update_structured_styles({image_type: image_url})
 
     async def upload_banner_additional_image(
         self,
-        image_path: str,
+        media: asyncpraw.models.StylesheetAsset,
+        /,
         *,
         align: str | None = None,
     ) -> None:
         """Upload an image for the :class:`.Subreddit`'s (redesign) additional image.
 
-        :param image_path: A path to a jpeg or png image.
+        :param media: The :class:`.StylesheetAsset` to upload.
         :param align: Either ``"left"``, ``"centered"``, or ``"right"``. (default:
             ``"left"``).
 
@@ -1865,8 +1817,10 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
+            from asyncpraw.models import StylesheetAsset
+
             subreddit = await reddit.subreddit("test")
-            await subreddit.stylesheet.upload_banner_additional_image("banner.png")
+            await subreddit.stylesheet.upload_banner_additional_image(StylesheetAsset("banner.png"))
 
         """
         alignment = {}
@@ -1877,16 +1831,16 @@ class SubredditStylesheet:
             alignment["bannerPositionedImagePosition"] = align
 
         image_type = "bannerPositionedImage"
-        image_url = await self._upload_style_asset(image_path=image_path, image_type=image_type)
+        image_url = await media._upload(self.subreddit, image_type=image_type)
         style_data = {image_type: image_url}
         if alignment:
             style_data.update(alignment)
         await self._update_structured_styles(style_data)
 
-    async def upload_banner_hover_image(self, image_path: str) -> None:
+    async def upload_banner_hover_image(self, media: asyncpraw.models.StylesheetAsset, /) -> None:
         """Upload an image for the :class:`.Subreddit`'s (redesign) additional image.
 
-        :param image_path: A path to a jpeg or png image.
+        :param media: The :class:`.StylesheetAsset` to upload.
 
         Fails if the :class:`.Subreddit` does not have an additional image defined.
 
@@ -1900,18 +1854,20 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
+            from asyncpraw.models import StylesheetAsset
+
             subreddit = await reddit.subreddit("test")
-            await subreddit.stylesheet.upload_banner_hover_image("banner.png")
+            await subreddit.stylesheet.upload_banner_hover_image(StylesheetAsset("banner.png"))
 
         """
         image_type = "secondaryBannerPositionedImage"
-        image_url = await self._upload_style_asset(image_path=image_path, image_type=image_type)
+        image_url = await media._upload(self.subreddit, image_type=image_type)
         await self._update_structured_styles({image_type: image_url})
 
-    async def upload_header(self, image_path: str) -> dict[str, str]:
+    async def upload_header(self, media: asyncpraw.models.StylesheetImage, /) -> dict[str, str]:
         """Upload an image to be used as the :class:`.Subreddit`'s header image.
 
-        :param image_path: A path to a jpeg or png image.
+        :param media: The :class:`.StylesheetImage` to upload.
 
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
@@ -1926,23 +1882,27 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
+            from asyncpraw.models import StylesheetImage
+
             subreddit = await reddit.subreddit("test")
-            await subreddit.stylesheet.upload_header("header.png")
+            await subreddit.stylesheet.upload_header(StylesheetImage("header.png"))
 
         """
-        return await self._upload_image(data={"upload_type": "header"}, image_path=image_path)
+        return await media._upload(self.subreddit, upload_type="header")
 
-    async def upload_mobile_banner(self, image_path: str) -> None:
+    async def upload_mobile_banner(self, media: asyncpraw.models.StylesheetAsset, /) -> None:
         """Upload an image for the :class:`.Subreddit`'s (redesign) mobile banner.
 
-        :param image_path: A path to a JPEG or PNG image.
+        :param media: The :class:`.StylesheetAsset` to upload.
 
         For example:
 
         .. code-block:: python
 
+            from asyncpraw.models import StylesheetAsset
+
             subreddit = await reddit.subreddit("test")
-            await subreddit.stylesheet.upload_mobile_banner("banner.png")
+            await subreddit.stylesheet.upload_mobile_banner(StylesheetAsset("banner.png"))
 
         Fails if the :class:`.Subreddit` does not have an additional image defined.
 
@@ -1954,13 +1914,13 @@ class SubredditStylesheet:
 
         """
         image_type = "mobileBannerImage"
-        image_url = await self._upload_style_asset(image_path=image_path, image_type=image_type)
+        image_url = await media._upload(self.subreddit, image_type=image_type)
         await self._update_structured_styles({image_type: image_url})
 
-    async def upload_mobile_header(self, image_path: str) -> dict[str, str]:
+    async def upload_mobile_header(self, media: asyncpraw.models.StylesheetImage, /) -> dict[str, str]:
         """Upload an image to be used as the :class:`.Subreddit`'s mobile header.
 
-        :param image_path: A path to a jpeg or png image.
+        :param media: The :class:`.StylesheetImage` to upload.
 
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
@@ -1975,16 +1935,18 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
+            from asyncpraw.models import StylesheetImage
+
             subreddit = await reddit.subreddit("test")
-            await subreddit.stylesheet.upload_mobile_header("header.png")
+            await subreddit.stylesheet.upload_mobile_header(StylesheetImage("header.png"))
 
         """
-        return await self._upload_image(data={"upload_type": "banner"}, image_path=image_path)
+        return await media._upload(self.subreddit, upload_type="banner")
 
-    async def upload_mobile_icon(self, image_path: str) -> dict[str, str]:
+    async def upload_mobile_icon(self, media: asyncpraw.models.StylesheetImage, /) -> dict[str, str]:
         """Upload an image to be used as the :class:`.Subreddit`'s mobile icon.
 
-        :param image_path: A path to a jpeg or png image.
+        :param media: The :class:`.StylesheetImage` to upload.
 
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
@@ -1999,11 +1961,13 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
+            from asyncpraw.models import StylesheetImage
+
             subreddit = await reddit.subreddit("test")
-            await subreddit.stylesheet.upload_mobile_icon("icon.png")
+            await subreddit.stylesheet.upload_mobile_icon(StylesheetImage("icon.png"))
 
         """
-        return await self._upload_image(data={"upload_type": "icon"}, image_path=image_path)
+        return await media._upload(self.subreddit, upload_type="icon")
 
 
 class SubredditWiki:
@@ -2593,19 +2557,6 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         await _reddit.post(API_PATH["site_admin"], data=model)
 
     @staticmethod
-    async def _parse_xml_response(response: ClientResponse) -> None:
-        """Parse the XML from a response and raise any errors found."""
-        xml = await response.text()
-        root = ElementTree.fromstring(xml)
-        tags = [element.tag for element in root]
-        if tags[:4] == ["Code", "Message", "ProposedSize", "MaxSizeAllowed"]:
-            # Returned if image is too big
-            _code, _message, actual, maximum_size = (element.text for element in root[:4])
-            assert actual is not None
-            assert maximum_size is not None
-            raise TooLargeMediaException(actual=int(actual), maximum_size=int(maximum_size))
-
-    @staticmethod
     def _subreddit_list(
         *,
         other_subreddits: Sequence[str | asyncpraw.models.Subreddit] | None,
@@ -2616,25 +2567,21 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         return str(subreddit)
 
     @staticmethod
-    def _validate_gallery(images: list[dict[str, str]]) -> None:
+    def _validate_gallery(images: list[dict[str, str | PostMedia]]) -> None:
         for image in images:
-            image_path = image.get("image_path", "")
-            if image_path:
-                if not Path(image_path).is_file():
-                    msg = f"{image_path!r} is not a valid image path."
-                    raise TypeError(msg)
-            else:
-                msg = "'image_path' is required."
+            media = image.get("media")
+            if not isinstance(media, PostMedia):
+                msg = "'media' is required and must be a PostMedia instance."
                 raise TypeError(msg)
-            if not len(image.get("caption", "")) <= Subreddit.MAX_CAPTION_LENGTH:
+            if not len(cast("str", image.get("caption", ""))) <= Subreddit.MAX_CAPTION_LENGTH:
                 msg = "Caption must be 180 characters or less."
                 raise TypeError(msg)
 
     @staticmethod
     def _validate_inline_media(inline_media: asyncpraw.models.InlineMedia) -> None:
-        if not Path(inline_media.path).is_file():
-            msg = f"{inline_media.path!r} is not a valid file path."
-            raise ValueError(msg)
+        if not isinstance(inline_media.media, PostMedia):
+            msg = "'media' must be a PostMedia instance."
+            raise TypeError(msg)
 
     @cachedproperty
     def banned(self) -> SubredditRelationship:
@@ -3031,16 +2978,6 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
     def _fetch_info(self) -> tuple[str, dict[str, RedditBase], None]:
         return "subreddit_about", {"subreddit": self}, None
 
-    @asynccontextmanager
-    async def _read_and_post_media(
-        self, file: Path, upload_url: str, upload_data: dict[str, Any]
-    ) -> AsyncGenerator[ClientResponse]:
-        assert self._reddit._core is not None
-        with file.open("rb") as media:
-            upload_data["file"] = media
-            async with self._reddit._core.requestor.request("POST", upload_url, data=upload_data) as response:
-                yield response
-
     async def _submit_media(
         self, *, data: dict[Any, Any], timeout: int, without_websockets: bool
     ) -> asyncpraw.models.Submission | None:
@@ -3084,69 +3021,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
 
         """
         self._validate_inline_media(inline_media)
-        inline_media.media_id = await self._upload_media(media_path=inline_media.path, upload_type="selfpost")
+        inline_media.media_id = await inline_media.media._upload(self._reddit, upload_type="selfpost")
         return inline_media
-
-    async def _upload_media(
-        self,
-        *,
-        expected_mime_prefix: str | None = None,
-        media_path: str | None,
-        upload_type: str = "link",
-    ) -> str:
-        """Upload media and return its URL and a websocket (Undocumented endpoint).
-
-        :param expected_mime_prefix: If provided, enforce that the media has a mime type
-            that starts with the provided prefix.
-        :param media_path: The path to the media file to upload. Default is the PRAW
-            logo.
-        :param upload_type: One of ``"link"``, ``"gallery"'', or ``"selfpost"``
-            (default: ``"link"``).
-
-        :returns: The link to the uploaded media.
-
-        """
-        if media_path is None:
-            # if we're uploading without a media path, assume we're uploading a PRAW logo
-            # this default is commonly used when ``video_poster_url`` is not provided in ``submit_video``
-            module_path = Path(__file__).absolute()  # noqa: ASYNC240
-            logo_path = module_path.parent.parent.parent / "images" / "PRAW logo.png"
-            file = Path(logo_path)
-        else:
-            file = Path(media_path)
-
-        file_name = file.name.lower()
-        file_extension = file_name.rpartition(".")[2]
-        mime_type = {
-            "png": "image/png",
-            "mov": "video/quicktime",
-            "mp4": "video/mp4",
-            "jpg": "image/jpeg",
-            "jpeg": "image/jpeg",
-            "gif": "image/gif",
-        }.get(file_extension, "image/jpeg")  # default to JPEG
-        if expected_mime_prefix is not None and mime_type.partition("/")[0] != expected_mime_prefix:
-            msg = f"Expected a mimetype starting with {expected_mime_prefix!r} but got mimetype {mime_type!r} (from file extension {file_extension!r})."
-            raise ClientException(msg)
-        img_data = {"filepath": file_name, "mimetype": mime_type}
-
-        url = API_PATH["media_asset"]
-        # until we learn otherwise, assume this request always succeeds
-        upload_response = await self._reddit.post(url, data=img_data)
-        upload_lease = upload_response["args"]
-        upload_url = f"https:{upload_lease['action']}"
-        upload_data = {item["name"]: item["value"] for item in upload_lease["fields"]}
-
-        async with self._read_and_post_media(file, upload_url, upload_data) as response:
-            if response.status != 201:  # noqa: PLR2004
-                await self._parse_xml_response(response)
-            try:
-                response.raise_for_status()
-            except HttpProcessingError:
-                raise ServerError(response=response) from None
-        if upload_type == "link":
-            return f"{upload_url}/{upload_data['key']}"
-        return upload_response["asset"]["asset_id"]
 
     async def post_requirements(self) -> dict[str, str | int | bool]:
         """Get the post requirements for a subreddit.
@@ -3322,11 +3198,11 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
 
         .. code-block:: python
 
-            from asyncpraw.models import InlineGif, InlineImage, InlineVideo
+            from asyncpraw.models import InlineGif, InlineImage, InlineVideo, PostMedia
 
-            gif = InlineGif(path="path/to/image.gif", caption="optional caption")
-            image = InlineImage(path="path/to/image.jpg", caption="optional caption")
-            video = InlineVideo(path="path/to/video.mp4", caption="optional caption")
+            gif = InlineGif(caption="optional caption", media=PostMedia("path/to/image.gif"))
+            image = InlineImage(caption="optional caption", media=PostMedia("path/to/image.jpg"))
+            video = InlineVideo(caption="optional caption", media=PostMedia("path/to/video.mp4"))
             selftext = "Text with a gif {gif1} an image {image1} and a video {video1} inline"
             media = {"gif1": gif, "image1": image, "video1": video}
             subreddit = await reddit.subreddit("test")
@@ -3434,7 +3310,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
     async def submit_gallery(
         self,
         title: str,
-        images: list[dict[str, str]],
+        images: list[PostMedia | dict[str, str | PostMedia]],
         *,
         collection_id: str | None = None,
         discussion_type: str | None = None,
@@ -3448,9 +3324,10 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         """Add an image gallery submission to the subreddit.
 
         :param title: The title of the submission.
-        :param images: The images to post in dict with the following structure:
-            ``{"image_path": "path", "caption": "caption", "outbound_url": "url"}``,
-            only ``image_path`` is required.
+        :param images: A list of images to post as a gallery. Each item is either a
+            :class:`.PostMedia` or a ``dict`` with the structure ``{"media":
+            PostMedia("path"), "caption": "caption", "outbound_url": "url"}``, where only
+            ``media`` is required.
         :param collection_id: The UUID of a :class:`.Collection` to add the
             newly-submitted post to.
         :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
@@ -3469,25 +3346,24 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
 
         :returns: A :class:`.Submission` object for the newly created submission.
 
-        :raises: :class:`.ClientException` if ``image_path`` in ``images`` refers to a
-            file that is not an image.
+        :raises: :class:`.ClientException` if a gallery item's ``media`` refers to a file
+            that is not an image.
 
         For example, to submit an image gallery to r/test do:
 
         .. code-block:: python
 
+            from asyncpraw.models import PostMedia
+
             title = "My favorite pictures"
-            image = "/path/to/image.png"
-            image2 = "/path/to/image2.png"
-            image3 = "/path/to/image3.png"
             images = [
-                {"image_path": image},
+                PostMedia("/path/to/image.png"),
                 {
-                    "image_path": image2,
+                    "media": PostMedia("/path/to/image2.png"),
                     "caption": "Image caption 2",
                 },
                 {
-                    "image_path": image3,
+                    "media": PostMedia("/path/to/image3.png"),
                     "caption": "Image caption 3",
                     "outbound_url": "https://example.com/link3",
                 },
@@ -3503,7 +3379,10 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
             - :meth:`~.Subreddit.submit_video` to submit videos and videogifs
 
         """
-        self._validate_gallery(images)
+        gallery_images: list[dict[str, str | PostMedia]] = [
+            {"media": item} if isinstance(item, PostMedia) else item for item in images
+        ]
+        self._validate_gallery(gallery_images)
         data = {
             "api_type": "json",
             "items": [],
@@ -3526,16 +3405,14 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
             )
             if value is not None
         })
-        for image in images:
+        for image in gallery_images:
             data["items"].append({
                 "caption": image.get("caption", ""),
                 "outbound_url": image.get("outbound_url", ""),
-                "media_id": (
-                    await self._upload_media(
-                        expected_mime_prefix="image",
-                        media_path=image["image_path"],
-                        upload_type="gallery",
-                    )
+                "media_id": await cast("PostMedia", image["media"])._upload(
+                    self._reddit,
+                    expected_mime_prefix="image",
+                    upload_type="gallery",
                 ),
             })
         response = await self._reddit.request(json=data, method="POST", path=API_PATH["submit_gallery_post"])
@@ -3547,7 +3424,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
     async def submit_image(
         self,
         title: str,
-        image_path: str,
+        image: PostMedia,
         *,
         collection_id: str | None = None,
         discussion_type: str | None = None,
@@ -3571,7 +3448,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         :param flair_text: If the template's ``flair_text_editable`` value is ``True``,
             this value will set a custom text (default: ``None``). ``flair_id`` is
             required when ``flair_text`` is provided.
-        :param image_path: The path to an image, to upload and post.
+        :param image: The :class:`.PostMedia` image to upload and post.
         :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
         :param resubmit: When ``False``, an error will occur if the URL has already been
             submitted (default: ``True``).
@@ -3591,8 +3468,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         :returns: A :class:`.Submission` object for the newly created submission, unless
             ``without_websockets`` is ``True``.
 
-        :raises: :class:`.ClientException` if ``image_path`` refers to a file that is
-            not an image.
+        :raises: :class:`.ClientException` if ``image`` refers to a file that is not an
+            image.
 
         .. note::
 
@@ -3611,8 +3488,10 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
 
         .. code-block:: python
 
+            from asyncpraw.models import PostMedia
+
             title = "My favorite picture"
-            image = "/path/to/image.png"
+            image = PostMedia("/path/to/image.png")
             subreddit = await reddit.subreddit("test")
             await subreddit.submit_image(title, image)
 
@@ -3646,7 +3525,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
             if value is not None
         })
 
-        image_url = await self._upload_media(expected_mime_prefix="image", media_path=image_path)
+        image_url = await image._upload(self._reddit, expected_mime_prefix="image")
         data.update(kind="image", url=image_url)
         return await self._submit_media(data=data, timeout=timeout, without_websockets=without_websockets)
 
@@ -3737,7 +3616,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
     async def submit_video(
         self,
         title: str,
-        video_path: str,
+        video: PostMedia | dict[str, bool | PostMedia],
         *,
         collection_id: str | None = None,
         discussion_type: str | None = None,
@@ -3748,15 +3627,18 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         selftext: str | None = None,
         send_replies: bool = True,
         spoiler: bool = False,
-        thumbnail_path: str | None = None,
         timeout: int = 10,
-        videogif: bool = False,
         without_websockets: bool = False,
     ) -> asyncpraw.models.Submission | None:
         """Add a video or videogif submission to the subreddit.
 
         :param title: The title of the submission.
-        :param video_path: The path to a video, to upload and post.
+        :param video: The video to upload and post. Either a :class:`.PostMedia` or a
+            ``dict`` with the structure ``{"media": PostMedia("path"), "gif": True,
+            "thumbnail": PostMedia("path")}``, where only ``media`` is required. Set
+            ``"gif"`` to ``True`` to submit the video as a videogif, which is essentially
+            a silent video (default: ``False``). When ``"thumbnail"`` is not provided,
+            the PRAW logo will be used as the thumbnail.
         :param collection_id: The UUID of a :class:`.Collection` to add the
             newly-submitted post to.
         :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
@@ -3774,13 +3656,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
             author when comments are made to the submission (default: ``True``).
         :param spoiler: Whether the submission should be marked as a spoiler (default:
             ``False``).
-        :param thumbnail_path: The path to an image, to be uploaded and used as the
-            thumbnail for this video. If not provided, the PRAW logo will be used as the
-            thumbnail.
         :param timeout: Specifies a particular timeout, in seconds. Use to avoid
             "Websocket error" exceptions (default: ``10``).
-        :param videogif: If ``True``, the video is uploaded as a videogif, which is
-            essentially a silent video (default: ``False``).
         :param without_websockets: Set to ``True`` to disable use of WebSockets (see
             note below for an explanation). If ``True``, this method doesn't return
             anything (default: ``False``).
@@ -3788,8 +3665,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         :returns: A :class:`.Submission` object for the newly created submission, unless
             ``without_websockets`` is ``True``.
 
-        :raises: :class:`.ClientException` if ``video_path`` refers to a file that is
-            not a video.
+        :raises: :class:`.ClientException` if ``video`` (or its ``media``) refers to a
+            file that is not a video.
 
         .. note::
 
@@ -3808,8 +3685,25 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
 
         .. code-block:: python
 
+            from asyncpraw.models import PostMedia
+
             title = "My favorite movie"
-            video = "/path/to/video.mp4"
+            video = PostMedia("/path/to/video.mp4")
+            subreddit = await reddit.subreddit("test")
+            await subreddit.submit_video(title, video)
+
+        To submit a videogif with a custom thumbnail instead, do:
+
+        .. code-block:: python
+
+            from asyncpraw.models import PostMedia
+
+            title = "My favorite gif"
+            video = {
+                "gif": True,
+                "media": PostMedia("/path/to/video.mp4"),
+                "thumbnail": PostMedia("/path/to/thumbnail.png"),
+            }
             subreddit = await reddit.subreddit("test")
             await subreddit.submit_video(title, video)
 
@@ -3822,6 +3716,22 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
             - :meth:`~.Subreddit.submit_poll` to submit polls
 
         """
+        if isinstance(video, PostMedia):
+            video = {"media": video}
+        invalid_keys = video.keys() - {"gif", "media", "thumbnail"}
+        if invalid_keys:
+            msg = f"'video' contains invalid keys: {', '.join(repr(key) for key in sorted(invalid_keys))}."
+            raise TypeError(msg)
+        video_media = video.get("media")
+        if not isinstance(video_media, PostMedia):
+            msg = "'media' is required and must be a PostMedia instance."
+            raise TypeError(msg)
+        thumbnail_media = cast("PostMedia | None", video.get("thumbnail"))
+        if thumbnail_media is None:
+            # if we're uploading without a thumbnail, use the PRAW logo
+            logo_path = Path(__file__).absolute().parent.parent.parent / "images" / "PRAW logo.png"  # noqa: ASYNC240
+            thumbnail_media = PostMedia(str(logo_path))
+
         data = {
             "sr": str(self),
             "resubmit": bool(resubmit),
@@ -3843,13 +3753,10 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
             if value is not None
         })
 
-        video_url = await self._upload_media(expected_mime_prefix="video", media_path=video_path)
-        video_poster_url = await self._upload_media(media_path=thumbnail_path)
         data.update(
-            kind="videogif" if videogif else "video",
-            url=video_url,
-            # if thumbnail_path is None, it uploads the PRAW logo
-            video_poster_url=video_poster_url,
+            kind="videogif" if video.get("gif") else "video",
+            url=await video_media._upload(self._reddit, expected_mime_prefix="video"),
+            video_poster_url=await thumbnail_media._upload(self._reddit),
         )
         return await self._submit_media(data=data, timeout=timeout, without_websockets=without_websockets)
 

--- a/asyncpraw/models/reddit/subreddit.py
+++ b/asyncpraw/models/reddit/subreddit.py
@@ -9,7 +9,7 @@ from csv import writer
 from io import StringIO
 from json import dumps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, overload
 from urllib.parse import urljoin
 
 from aiohttp import WebSocketError
@@ -3134,6 +3134,113 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         await submission._fetch()
         return submission
 
+    @overload
+    async def submit(
+        self,
+        title: str,
+        *,
+        collection_id: str | None = ...,
+        discussion_type: str | None = ...,
+        draft_id: str | None = ...,
+        flair_id: str | None = ...,
+        flair_text: str | None = ...,
+        inline_media: dict[str, asyncpraw.models.InlineMedia] | None = ...,
+        nsfw: bool = ...,
+        resubmit: bool = ...,
+        selftext: str,
+        send_replies: bool = ...,
+        spoiler: bool = ...,
+    ) -> asyncpraw.models.Submission: ...
+
+    @overload
+    async def submit(
+        self,
+        title: str,
+        *,
+        collection_id: str | None = ...,
+        discussion_type: str | None = ...,
+        draft_id: str | None = ...,
+        flair_id: str | None = ...,
+        flair_text: str | None = ...,
+        nsfw: bool = ...,
+        resubmit: bool = ...,
+        selftext: str | None = ...,
+        send_replies: bool = ...,
+        spoiler: bool = ...,
+        url: str,
+    ) -> asyncpraw.models.Submission: ...
+
+    @overload
+    async def submit(
+        self,
+        title: str,
+        *,
+        collection_id: str | None = ...,
+        discussion_type: str | None = ...,
+        flair_id: str | None = ...,
+        flair_text: str | None = ...,
+        image: asyncpraw.models.PostMedia,
+        nsfw: bool = ...,
+        resubmit: bool = ...,
+        selftext: str | None = ...,
+        send_replies: bool = ...,
+        spoiler: bool = ...,
+        timeout: int = ...,
+        without_websockets: bool = ...,
+    ) -> asyncpraw.models.Submission | None: ...
+
+    @overload
+    async def submit(
+        self,
+        title: str,
+        *,
+        collection_id: str | None = ...,
+        discussion_type: str | None = ...,
+        flair_id: str | None = ...,
+        flair_text: str | None = ...,
+        gallery: list[asyncpraw.models.PostMedia | dict[str, str | asyncpraw.models.PostMedia]],
+        nsfw: bool = ...,
+        selftext: str | None = ...,
+        send_replies: bool = ...,
+        spoiler: bool = ...,
+    ) -> asyncpraw.models.Submission: ...
+
+    @overload
+    async def submit(
+        self,
+        title: str,
+        *,
+        collection_id: str | None = ...,
+        discussion_type: str | None = ...,
+        flair_id: str | None = ...,
+        flair_text: str | None = ...,
+        nsfw: bool = ...,
+        poll: dict[str, int | list[str]],
+        resubmit: bool = ...,
+        selftext: str | None = ...,
+        send_replies: bool = ...,
+        spoiler: bool = ...,
+    ) -> asyncpraw.models.Submission: ...
+
+    @overload
+    async def submit(
+        self,
+        title: str,
+        *,
+        collection_id: str | None = ...,
+        discussion_type: str | None = ...,
+        flair_id: str | None = ...,
+        flair_text: str | None = ...,
+        nsfw: bool = ...,
+        resubmit: bool = ...,
+        selftext: str | None = ...,
+        send_replies: bool = ...,
+        spoiler: bool = ...,
+        timeout: int = ...,
+        video: asyncpraw.models.PostMedia | dict[str, bool | asyncpraw.models.PostMedia],
+        without_websockets: bool = ...,
+    ) -> asyncpraw.models.Submission | None: ...
+
     async def submit(
         self,
         title: str,
@@ -3143,14 +3250,20 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         draft_id: str | None = None,
         flair_id: str | None = None,
         flair_text: str | None = None,
+        gallery: list[asyncpraw.models.PostMedia | dict[str, str | asyncpraw.models.PostMedia]] | None = None,
+        image: asyncpraw.models.PostMedia | None = None,
         inline_media: dict[str, asyncpraw.models.InlineMedia] | None = None,
         nsfw: bool = False,
+        poll: dict[str, int | list[str]] | None = None,
         resubmit: bool = True,
         selftext: str | None = None,
         send_replies: bool = True,
         spoiler: bool = False,
+        timeout: int = 10,
         url: str | None = None,
-    ) -> asyncpraw.models.Submission:
+        video: asyncpraw.models.PostMedia | dict[str, bool | asyncpraw.models.PostMedia] | None = None,
+        without_websockets: bool = False,
+    ) -> asyncpraw.models.Submission | None:
         r"""Add a submission to the :class:`.Subreddit`.
 
         :param title: The title of the submission.
@@ -3158,32 +3271,59 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
             newly-submitted post to.
         :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
             traditional comments (default: ``None``).
-        :param draft_id: The ID of a draft to submit.
+        :param draft_id: The ID of a draft to submit. Only applies to text and link
+            submissions.
         :param flair_id: The flair template to select (default: ``None``).
         :param flair_text: If the template's ``flair_text_editable`` value is ``True``,
             this value will set a custom text (default: ``None``). ``flair_id`` is
             required when ``flair_text`` is provided.
+        :param gallery: A list of images to post as a gallery. Each item is either a
+            :class:`.PostMedia` or a ``dict`` with the structure ``{"media":
+            PostMedia("path"), "caption": "caption", "outbound_url": "url"}``, where
+            only ``media`` is required.
+        :param image: The :class:`.PostMedia` image to upload and post.
         :param inline_media: A dict of :class:`.InlineMedia` objects where the key is
-            the placeholder name in ``selftext``. Link post selftext does not support
-            inline media.
+            the placeholder name in ``selftext``. Only supported for text submissions.
         :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
+        :param poll: A ``dict`` with the structure ``{"duration": 3, "options": ["Yes",
+            "No"]}``, where ``duration`` is the number of days the poll should accept
+            votes (between ``1`` and ``7``, inclusive) and ``options`` is a list of two
+            to six poll options as ``str``. Both keys are required.
         :param resubmit: When ``False``, an error will occur if the URL has already been
             submitted (default: ``True``).
-        :param selftext: The Markdown formatted content for a ``text`` submission or an
-            optional post body for ``link`` submissions. Use an empty string, ``""``, to
-            make a title-only submission.
+        :param selftext: The Markdown formatted content for a ``text`` submission or
+            optional Markdown-formatted body text for any other kind of submission. Use
+            an empty string, ``""``, to make a title-only submission.
         :param send_replies: When ``True``, messages will be sent to the submission
             author when comments are made to the submission (default: ``True``).
         :param spoiler: Whether the submission should be marked as a spoiler (default:
             ``False``).
+        :param timeout: Specifies a particular timeout, in seconds, for the WebSockets
+            connection used by ``image`` and ``video`` submissions. Use to avoid
+            "Websocket error" exceptions (default: ``10``).
         :param url: The URL for a ``link`` submission.
+        :param video: The video to upload and post. Either a :class:`.PostMedia` or a
+            ``dict`` with the structure ``{"media": PostMedia("path"), "gif": True,
+            "thumbnail": PostMedia("path")}``, where only ``media`` is required. Set
+            ``"gif"`` to ``True`` to submit the video as a videogif, which is
+            essentially a silent video (default: ``False``). When ``"thumbnail"`` is not
+            provided, the PRAW logo will be used as the thumbnail.
+        :param without_websockets: Set to ``True`` to disable use of WebSockets for
+            ``image`` and ``video`` submissions (see note below for an explanation). If
+            ``True``, this method doesn't return anything (default: ``False``).
 
-        :returns: A :class:`.Submission` object for the newly created submission.
+        :returns: A :class:`.Submission` object for the newly created submission, unless
+            ``without_websockets`` is ``True`` for an ``image`` or ``video`` submission.
 
-        Provide ``selftext`` alone for a ``text`` submission. ``selftext`` can accompany
-        a ``url`` for a ``link`` submission. ``selftext`` that accompanies a ``link``
-        submission is optional. ``selftext`` for ``link`` submissions does not support
-        ``inline_media``.
+        :raises: :class:`.ClientException` if ``image`` or a ``gallery`` item's
+            ``media`` refers to a file that is not an image, or if the ``video`` (or its
+            ``media``) refers to a file that is not a video.
+
+        At least one of ``gallery``, ``image``, ``poll``, ``selftext``, ``url``, or
+        ``video`` must be provided. ``gallery``, ``image``, ``poll``, ``url``, and
+        ``video`` are mutually exclusive, while ``selftext`` may accompany any of them
+        as optional Markdown-formatted body text. ``selftext`` that accompanies another
+        kind of submission does not support ``inline_media``.
 
         For example, to submit a URL to r/test do:
 
@@ -3194,7 +3334,75 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
             subreddit = await reddit.subreddit("test")
             await subreddit.submit(title, url=url)
 
-        For example, to submit a self post with inline media do:
+        To submit an image to r/test do:
+
+        .. code-block:: python
+
+            from asyncpraw.models import PostMedia
+
+            title = "My favorite picture"
+            image = PostMedia("/path/to/image.png")
+            subreddit = await reddit.subreddit("test")
+            await subreddit.submit(title, image=image)
+
+        To submit an image gallery to r/test do:
+
+        .. code-block:: python
+
+            from asyncpraw.models import PostMedia
+
+            title = "My favorite pictures"
+            gallery = [
+                PostMedia("/path/to/image.png"),
+                {
+                    "media": PostMedia("/path/to/image2.png"),
+                    "caption": "Image caption 2",
+                },
+                {
+                    "media": PostMedia("/path/to/image3.png"),
+                    "caption": "Image caption 3",
+                    "outbound_url": "https://example.com/link3",
+                },
+            ]
+            subreddit = await reddit.subreddit("test")
+            await subreddit.submit(title, gallery=gallery)
+
+        To submit a video to r/test do:
+
+        .. code-block:: python
+
+            from asyncpraw.models import PostMedia
+
+            title = "My favorite movie"
+            video = PostMedia("/path/to/video.mp4")
+            subreddit = await reddit.subreddit("test")
+            await subreddit.submit(title, video=video)
+
+        To submit a videogif with a custom thumbnail instead, do:
+
+        .. code-block:: python
+
+            from asyncpraw.models import PostMedia
+
+            title = "My favorite gif"
+            video = {
+                "gif": True,
+                "media": PostMedia("/path/to/video.mp4"),
+                "thumbnail": PostMedia("/path/to/thumbnail.png"),
+            }
+            subreddit = await reddit.subreddit("test")
+            await subreddit.submit(title, video=video)
+
+        To submit a poll to r/test do:
+
+        .. code-block:: python
+
+            title = "Do you like Async PRAW?"
+            poll = {"duration": 3, "options": ["Yes", "No"]}
+            subreddit = await reddit.subreddit("test")
+            await subreddit.submit(title, poll=poll)
+
+        To submit a self post with inline media do:
 
         .. code-block:: python
 
@@ -3211,7 +3419,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         .. note::
 
             Inserted media will have a padding of ``\\n\\n`` automatically added. This
-            is due to the weirdness with Reddit's API. Using the example above the
+            is due to the weirdness with Reddit's API. Using the example above, the
             result selftext body will look like so:
 
             .. code-block::
@@ -3229,6 +3437,20 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
                 ![video](gmc7rvthryq51 "optional caption")
 
                 inline
+
+        .. note::
+
+            For ``image`` and ``video`` submissions, Reddit's API uses WebSockets to
+            respond with the link of the newly created post. If this fails, the method
+            will raise :class:`.WebSocketException`. Occasionally, the Reddit post will
+            still be created. More often, there is an error with the media file. If you
+            frequently get exceptions but successfully created posts, try setting the
+            ``timeout`` parameter to a value above 10.
+
+            To disable the use of WebSockets, set ``without_websockets=True``. This will
+            make the method return ``None``, though the post will still be created. You
+            may wish to do this if you are running your program in a restricted network
+            environment, or using a proxy that doesn't support WebSockets connections.
 
         .. note::
 
@@ -3251,52 +3473,133 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
                 submission = await subreddit.submit(title, url=url)
                 await submission.load()
 
-        .. seealso::
-
-            - :meth:`~.Subreddit.submit_gallery` to submit more than one image in the
-              same post
-            - :meth:`~.Subreddit.submit_image` to submit images
-            - :meth:`~.Subreddit.submit_poll` to submit polls
-            - :meth:`~.Subreddit.submit_video` to submit videos and videogifs
-
         """
-        # link posts can now include selftext (no longer exclusive)
+        provided = [
+            name
+            for name, value in (
+                ("gallery", gallery),
+                ("image", image),
+                ("poll", poll),
+                ("url", url),
+                ("video", video),
+            )
+            if value is not None
+        ]
+        if len(provided) > 1:
+            msg = f"Only one of 'gallery', 'image', 'poll', 'url', or 'video' can be provided ({', '.join(repr(name) for name in provided)} given)."
+            raise TypeError(msg)
+        kind = provided[0] if provided else None
         # test for empty string in selftext for title-only submissions
-        if not url and not (bool(selftext) or selftext == ""):  # noqa: PLC1901
-            msg = "Either 'selftext' and/or 'url' must be provided."
+        if kind is None and not (bool(selftext) or selftext == ""):  # noqa: PLC1901
+            msg = "At least one of 'gallery', 'image', 'poll', 'selftext', 'url', or 'video' must be provided."
+            raise TypeError(msg)
+        if inline_media and kind is not None:
+            msg = f"'inline_media' is only supported for text submissions. Only Markdown text can be used for the selftext of a {kind!r} submission."
             raise TypeError(msg)
 
         data = {
-            "sr": str(self),
-            "resubmit": bool(resubmit),
-            "sendreplies": bool(send_replies),
-            "title": title,
             "nsfw": bool(nsfw),
+            "sendreplies": bool(send_replies),
             "spoiler": bool(spoiler),
+            "sr": str(self),
+            "title": title,
             "validate_on_submit": True,
         }
         data.update({
             key: value
             for key, value in (
-                ("flair_id", flair_id),
-                ("flair_text", flair_text),
                 ("collection_id", collection_id),
                 ("discussion_type", discussion_type),
-                ("draft_id", draft_id),
+                ("flair_id", flair_id),
+                ("flair_text", flair_text),
             )
             if value is not None
         })
+
+        if gallery is not None:
+            images: list[dict[str, str | asyncpraw.models.PostMedia]] = [
+                {"media": item} if isinstance(item, PostMedia) else item for item in gallery
+            ]
+            self._validate_gallery(images)
+            data.update(api_type="json", items=[], show_error_list=True)
+            if selftext is not None:
+                data["text"] = selftext
+            for image_item in images:
+                data["items"].append({
+                    "caption": image_item.get("caption", ""),
+                    "outbound_url": image_item.get("outbound_url", ""),
+                    "media_id": await cast("PostMedia", image_item["media"])._upload(
+                        self._reddit,
+                        expected_mime_prefix="image",
+                        upload_type="gallery",
+                    ),
+                })
+            response = await self._reddit.request(json=data, method="POST", path=API_PATH["submit_gallery_post"])
+            response = response["json"]
+            if response["errors"]:
+                raise RedditAPIException(response["errors"])
+            return await self._reddit.submission(url=response["data"]["url"])
+
+        data["resubmit"] = bool(resubmit)
+
+        if poll is not None:
+            invalid_keys = poll.keys() - {"duration", "options"}
+            if invalid_keys:
+                msg = f"'poll' contains invalid keys: {', '.join(repr(key) for key in sorted(invalid_keys))}."
+                raise TypeError(msg)
+            missing_keys = {"duration", "options"} - poll.keys()
+            if missing_keys:
+                msg = f"'poll' is missing required keys: {', '.join(repr(key) for key in sorted(missing_keys))}."
+                raise TypeError(msg)
+            data.update(
+                duration=poll["duration"],
+                options=poll["options"],
+                text=selftext if selftext is not None else "",
+            )
+            return await self._reddit.post(API_PATH["submit_poll_post"], json=data)
+
+        if image is not None:
+            if selftext is not None:
+                data["text"] = selftext
+            data.update(kind="image", url=await image._upload(self._reddit, expected_mime_prefix="image"))
+            return await self._submit_media(data=data, timeout=timeout, without_websockets=without_websockets)
+
+        if video is not None:
+            if isinstance(video, PostMedia):
+                video = {"media": video}
+            invalid_keys = video.keys() - {"gif", "media", "thumbnail"}
+            if invalid_keys:
+                msg = f"'video' contains invalid keys: {', '.join(repr(key) for key in sorted(invalid_keys))}."
+                raise TypeError(msg)
+            video_media = video.get("media")
+            if not isinstance(video_media, PostMedia):
+                msg = "'media' is required and must be a PostMedia instance."
+                raise TypeError(msg)
+            thumbnail_media = cast("PostMedia | None", video.get("thumbnail"))
+            if thumbnail_media is None:
+                # if we're uploading without a thumbnail, use the PRAW logo
+                logo_path = Path(__file__).absolute().parent.parent.parent / "images" / "PRAW logo.png"  # noqa: ASYNC240
+                thumbnail_media = PostMedia(str(logo_path))
+            if selftext is not None:
+                data["text"] = selftext
+            data.update(
+                kind="videogif" if video.get("gif") else "video",
+                url=await video_media._upload(self._reddit, expected_mime_prefix="video"),
+                video_poster_url=await thumbnail_media._upload(self._reddit),
+            )
+            return await self._submit_media(data=data, timeout=timeout, without_websockets=without_websockets)
+
+        if draft_id is not None:
+            data["draft_id"] = draft_id
         if url is not None:
             data.update(kind="link", url=url)
-            if inline_media:
-                msg = "As of 2025-10-08, `inline_media` is not supported for link post selftext. Only Markdown text can be added to non-self posts."
-                raise TypeError(msg)
             # we can ignore an empty string for selftext here b/c body text is optional for link posts
             if selftext:
-                data.update(text=selftext)
-        elif selftext is not None:
+                data["text"] = selftext
+        else:
             data.update(kind="self")
             if inline_media:
+                assert selftext is not None
                 body = selftext.format(**{
                     placeholder: await self._upload_inline_media(media) for placeholder, media in inline_media.items()
                 })
@@ -3306,459 +3609,6 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
                 data.update(text=selftext)
 
         return await self._reddit.post(API_PATH["submit"], data=data)
-
-    async def submit_gallery(
-        self,
-        title: str,
-        images: list[PostMedia | dict[str, str | PostMedia]],
-        *,
-        collection_id: str | None = None,
-        discussion_type: str | None = None,
-        flair_id: str | None = None,
-        flair_text: str | None = None,
-        nsfw: bool = False,
-        selftext: str | None = None,
-        send_replies: bool = True,
-        spoiler: bool = False,
-    ) -> asyncpraw.models.Submission:
-        """Add an image gallery submission to the subreddit.
-
-        :param title: The title of the submission.
-        :param images: A list of images to post as a gallery. Each item is either a
-            :class:`.PostMedia` or a ``dict`` with the structure ``{"media":
-            PostMedia("path"), "caption": "caption", "outbound_url": "url"}``, where only
-            ``media`` is required.
-        :param collection_id: The UUID of a :class:`.Collection` to add the
-            newly-submitted post to.
-        :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
-            traditional comments (default: ``None``).
-        :param flair_id: The flair template to select (default: ``None``).
-        :param flair_text: If the template's ``flair_text_editable`` value is ``True``,
-            this value will set a custom text (default: ``None``). ``flair_id`` is
-            required when ``flair_text`` is provided.
-        :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
-        :param selftext: Optional Markdown-formatted post body content (default:
-            ``None``).
-        :param send_replies: When ``True``, messages will be sent to the submission
-            author when comments are made to the submission (default: ``True``).
-        :param spoiler: Whether the submission should be marked asa spoiler (default:
-            ``False``).
-
-        :returns: A :class:`.Submission` object for the newly created submission.
-
-        :raises: :class:`.ClientException` if a gallery item's ``media`` refers to a file
-            that is not an image.
-
-        For example, to submit an image gallery to r/test do:
-
-        .. code-block:: python
-
-            from asyncpraw.models import PostMedia
-
-            title = "My favorite pictures"
-            images = [
-                PostMedia("/path/to/image.png"),
-                {
-                    "media": PostMedia("/path/to/image2.png"),
-                    "caption": "Image caption 2",
-                },
-                {
-                    "media": PostMedia("/path/to/image3.png"),
-                    "caption": "Image caption 3",
-                    "outbound_url": "https://example.com/link3",
-                },
-            ]
-            subreddit = await reddit.subreddit("test")
-            await subreddit.submit_gallery(title, images)
-
-        .. seealso::
-
-            - :meth:`~.Subreddit.submit` to submit url posts and selftexts
-            - :meth:`~.Subreddit.submit_image` to submit single images
-            - :meth:`~.Subreddit.submit_poll` to submit polls
-            - :meth:`~.Subreddit.submit_video` to submit videos and videogifs
-
-        """
-        gallery_images: list[dict[str, str | PostMedia]] = [
-            {"media": item} if isinstance(item, PostMedia) else item for item in images
-        ]
-        self._validate_gallery(gallery_images)
-        data = {
-            "api_type": "json",
-            "items": [],
-            "nsfw": bool(nsfw),
-            "sendreplies": bool(send_replies),
-            "show_error_list": True,
-            "spoiler": bool(spoiler),
-            "sr": str(self),
-            "title": title,
-            "validate_on_submit": True,
-        }
-        data.update({
-            key: value
-            for key, value in (
-                ("flair_id", flair_id),
-                ("flair_text", flair_text),
-                ("collection_id", collection_id),
-                ("discussion_type", discussion_type),
-                ("text", selftext),
-            )
-            if value is not None
-        })
-        for image in gallery_images:
-            data["items"].append({
-                "caption": image.get("caption", ""),
-                "outbound_url": image.get("outbound_url", ""),
-                "media_id": await cast("PostMedia", image["media"])._upload(
-                    self._reddit,
-                    expected_mime_prefix="image",
-                    upload_type="gallery",
-                ),
-            })
-        response = await self._reddit.request(json=data, method="POST", path=API_PATH["submit_gallery_post"])
-        response = response["json"]
-        if response["errors"]:
-            raise RedditAPIException(response["errors"])
-        return await self._reddit.submission(url=response["data"]["url"])
-
-    async def submit_image(
-        self,
-        title: str,
-        image: PostMedia,
-        *,
-        collection_id: str | None = None,
-        discussion_type: str | None = None,
-        flair_id: str | None = None,
-        flair_text: str | None = None,
-        nsfw: bool = False,
-        resubmit: bool = True,
-        selftext: str | None = None,
-        send_replies: bool = True,
-        spoiler: bool = False,
-        timeout: int = 10,
-        without_websockets: bool = False,
-    ) -> asyncpraw.models.Submission | None:
-        """Add an image submission to the subreddit.
-
-        :param collection_id: The UUID of a :class:`.Collection` to add the
-            newly-submitted post to.
-        :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
-            traditional comments (default: ``None``).
-        :param flair_id: The flair template to select (default: ``None``).
-        :param flair_text: If the template's ``flair_text_editable`` value is ``True``,
-            this value will set a custom text (default: ``None``). ``flair_id`` is
-            required when ``flair_text`` is provided.
-        :param image: The :class:`.PostMedia` image to upload and post.
-        :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
-        :param resubmit: When ``False``, an error will occur if the URL has already been
-            submitted (default: ``True``).
-        :param selftext: Optional Markdown-formatted post body content (default:
-            ``None``).
-        :param send_replies: When ``True``, messages will be sent to the submission
-            author when comments are made to the submission (default: ``True``).
-        :param spoiler: Whether the submission should be marked as a spoiler (default:
-            ``False``).
-        :param timeout: Specifies a particular timeout, in seconds. Use to avoid
-            "Websocket error" exceptions (default: ``10``).
-        :param title: The title of the submission.
-        :param without_websockets: Set to ``True`` to disable use of WebSockets (see
-            note below for an explanation). If ``True``, this method doesn't return
-            anything (default: ``False``).
-
-        :returns: A :class:`.Submission` object for the newly created submission, unless
-            ``without_websockets`` is ``True``.
-
-        :raises: :class:`.ClientException` if ``image`` refers to a file that is not an
-            image.
-
-        .. note::
-
-            Reddit's API uses WebSockets to respond with the link of the newly created
-            post. If this fails, the method will raise :class:`.WebSocketException`.
-            Occasionally, the Reddit post will still be created. More often, there is an
-            error with the image file. If you frequently get exceptions but successfully
-            created posts, try setting the ``timeout`` parameter to a value above 10.
-
-            To disable the use of WebSockets, set ``without_websockets=True``. This will
-            make the method return ``None``, though the post will still be created. You
-            may wish to do this if you are running your program in a restricted network
-            environment, or using a proxy that doesn't support WebSockets connections.
-
-        For example, to submit an image to r/test do:
-
-        .. code-block:: python
-
-            from asyncpraw.models import PostMedia
-
-            title = "My favorite picture"
-            image = PostMedia("/path/to/image.png")
-            subreddit = await reddit.subreddit("test")
-            await subreddit.submit_image(title, image)
-
-        .. seealso::
-
-            - :meth:`~.Subreddit.submit` to submit url posts and selftexts
-            - :meth:`~.Subreddit.submit_gallery` to submit more than one image in the
-              same post
-            - :meth:`~.Subreddit.submit_poll` to submit polls
-            - :meth:`~.Subreddit.submit_video` to submit videos and videogifs
-
-        """
-        data = {
-            "sr": str(self),
-            "resubmit": bool(resubmit),
-            "sendreplies": bool(send_replies),
-            "title": title,
-            "nsfw": bool(nsfw),
-            "spoiler": bool(spoiler),
-            "validate_on_submit": True,
-        }
-        data.update({
-            key: value
-            for key, value in (
-                ("flair_id", flair_id),
-                ("flair_text", flair_text),
-                ("collection_id", collection_id),
-                ("discussion_type", discussion_type),
-                ("text", selftext),
-            )
-            if value is not None
-        })
-
-        image_url = await image._upload(self._reddit, expected_mime_prefix="image")
-        data.update(kind="image", url=image_url)
-        return await self._submit_media(data=data, timeout=timeout, without_websockets=without_websockets)
-
-    async def submit_poll(
-        self,
-        title: str,
-        *,
-        collection_id: str | None = None,
-        discussion_type: str | None = None,
-        duration: int,
-        flair_id: str | None = None,
-        flair_text: str | None = None,
-        nsfw: bool = False,
-        options: list[str],
-        resubmit: bool = True,
-        selftext: str,
-        send_replies: bool = True,
-        spoiler: bool = False,
-    ) -> asyncpraw.models.Submission:
-        """Add a poll submission to the subreddit.
-
-        :param title: The title of the submission.
-        :param collection_id: The UUID of a :class:`.Collection` to add the
-            newly-submitted post to.
-        :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
-            traditional comments (default: ``None``).
-        :param duration: The number of days the poll should accept votes, as an ``int``.
-            Valid values are between ``1`` and ``7``, inclusive.
-        :param flair_id: The flair template to select (default: ``None``).
-        :param flair_text: If the template's ``flair_text_editable`` value is ``True``,
-            this value will set a custom text (default: ``None``). ``flair_id`` is
-            required when ``flair_text`` is provided.
-        :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
-        :param options: A list of two to six poll options as ``str``.
-        :param resubmit: When ``False``, an error will occur if the URL has already been
-            submitted (default: ``True``).
-        :param selftext: The Markdown formatted content for the submission. Use an empty
-            string, ``""``, to make a submission with no text contents.
-        :param send_replies: When ``True``, messages will be sent to the submission
-            author when comments are made to the submission (default: ``True``).
-        :param spoiler: Whether the submission should be marked as a spoiler (default:
-            ``False``).
-
-        :returns: A :class:`.Submission` object for the newly created submission.
-
-        For example, to submit a poll to r/test do:
-
-        .. code-block:: python
-
-            title = "Do you like Async PRAW?"
-            subreddit = await reddit.subreddit("test")
-            await subreddit.submit_poll(title, selftext="", options=["Yes", "No"], duration=3)
-
-        .. seealso::
-
-            - :meth:`~.Subreddit.submit` to submit url posts and selftexts
-            - :meth:`~.Subreddit.submit_gallery` to submit more than one image in the
-              same post
-            - :meth:`~.Subreddit.submit_image` to submit single images
-            - :meth:`~.Subreddit.submit_video` to submit videos and videogifs
-
-        """
-        data = {
-            "sr": str(self),
-            "text": selftext,
-            "options": options,
-            "duration": duration,
-            "resubmit": bool(resubmit),
-            "sendreplies": bool(send_replies),
-            "title": title,
-            "nsfw": bool(nsfw),
-            "spoiler": bool(spoiler),
-            "validate_on_submit": True,
-        }
-        data.update({
-            key: value
-            for key, value in (
-                ("flair_id", flair_id),
-                ("flair_text", flair_text),
-                ("collection_id", collection_id),
-                ("discussion_type", discussion_type),
-            )
-            if value is not None
-        })
-
-        return await self._reddit.post(API_PATH["submit_poll_post"], json=data)
-
-    async def submit_video(
-        self,
-        title: str,
-        video: PostMedia | dict[str, bool | PostMedia],
-        *,
-        collection_id: str | None = None,
-        discussion_type: str | None = None,
-        flair_id: str | None = None,
-        flair_text: str | None = None,
-        nsfw: bool = False,
-        resubmit: bool = True,
-        selftext: str | None = None,
-        send_replies: bool = True,
-        spoiler: bool = False,
-        timeout: int = 10,
-        without_websockets: bool = False,
-    ) -> asyncpraw.models.Submission | None:
-        """Add a video or videogif submission to the subreddit.
-
-        :param title: The title of the submission.
-        :param video: The video to upload and post. Either a :class:`.PostMedia` or a
-            ``dict`` with the structure ``{"media": PostMedia("path"), "gif": True,
-            "thumbnail": PostMedia("path")}``, where only ``media`` is required. Set
-            ``"gif"`` to ``True`` to submit the video as a videogif, which is essentially
-            a silent video (default: ``False``). When ``"thumbnail"`` is not provided,
-            the PRAW logo will be used as the thumbnail.
-        :param collection_id: The UUID of a :class:`.Collection` to add the
-            newly-submitted post to.
-        :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
-            traditional comments (default: ``None``).
-        :param flair_id: The flair template to select (default: ``None``).
-        :param flair_text: If the template's ``flair_text_editable`` value is ``True``,
-            this value will set a custom text (default: ``None``). ``flair_id`` is
-            required when ``flair_text`` is provided.
-        :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
-        :param resubmit: When ``False``, an error will occur if the URL has already been
-            submitted (default: ``True``).
-        :param selftext: Optional Markdown-formatted post body content (default:
-            ``None``).
-        :param send_replies: When ``True``, messages will be sent to the submission
-            author when comments are made to the submission (default: ``True``).
-        :param spoiler: Whether the submission should be marked as a spoiler (default:
-            ``False``).
-        :param timeout: Specifies a particular timeout, in seconds. Use to avoid
-            "Websocket error" exceptions (default: ``10``).
-        :param without_websockets: Set to ``True`` to disable use of WebSockets (see
-            note below for an explanation). If ``True``, this method doesn't return
-            anything (default: ``False``).
-
-        :returns: A :class:`.Submission` object for the newly created submission, unless
-            ``without_websockets`` is ``True``.
-
-        :raises: :class:`.ClientException` if ``video`` (or its ``media``) refers to a
-            file that is not a video.
-
-        .. note::
-
-            Reddit's API uses WebSockets to respond with the link of the newly created
-            post. If this fails, the method will raise :class:`.WebSocketException`.
-            Occasionally, the Reddit post will still be created. More often, there is an
-            error with the image file. If you frequently get exceptions but successfully
-            created posts, try setting the ``timeout`` parameter to a value above 10.
-
-            To disable the use of WebSockets, set ``without_websockets=True``. This will
-            make the method return ``None``, though the post will still be created. You
-            may wish to do this if you are running your program in a restricted network
-            environment, or using a proxy that doesn't support WebSockets connections.
-
-        For example, to submit a video to r/test do:
-
-        .. code-block:: python
-
-            from asyncpraw.models import PostMedia
-
-            title = "My favorite movie"
-            video = PostMedia("/path/to/video.mp4")
-            subreddit = await reddit.subreddit("test")
-            await subreddit.submit_video(title, video)
-
-        To submit a videogif with a custom thumbnail instead, do:
-
-        .. code-block:: python
-
-            from asyncpraw.models import PostMedia
-
-            title = "My favorite gif"
-            video = {
-                "gif": True,
-                "media": PostMedia("/path/to/video.mp4"),
-                "thumbnail": PostMedia("/path/to/thumbnail.png"),
-            }
-            subreddit = await reddit.subreddit("test")
-            await subreddit.submit_video(title, video)
-
-        .. seealso::
-
-            - :meth:`~.Subreddit.submit` to submit url posts and selftexts
-            - :meth:`~.Subreddit.submit_image` to submit images
-            - :meth:`~.Subreddit.submit_gallery` to submit more than one image in the
-              same post
-            - :meth:`~.Subreddit.submit_poll` to submit polls
-
-        """
-        if isinstance(video, PostMedia):
-            video = {"media": video}
-        invalid_keys = video.keys() - {"gif", "media", "thumbnail"}
-        if invalid_keys:
-            msg = f"'video' contains invalid keys: {', '.join(repr(key) for key in sorted(invalid_keys))}."
-            raise TypeError(msg)
-        video_media = video.get("media")
-        if not isinstance(video_media, PostMedia):
-            msg = "'media' is required and must be a PostMedia instance."
-            raise TypeError(msg)
-        thumbnail_media = cast("PostMedia | None", video.get("thumbnail"))
-        if thumbnail_media is None:
-            # if we're uploading without a thumbnail, use the PRAW logo
-            logo_path = Path(__file__).absolute().parent.parent.parent / "images" / "PRAW logo.png"  # noqa: ASYNC240
-            thumbnail_media = PostMedia(str(logo_path))
-
-        data = {
-            "sr": str(self),
-            "resubmit": bool(resubmit),
-            "sendreplies": bool(send_replies),
-            "title": title,
-            "nsfw": bool(nsfw),
-            "spoiler": bool(spoiler),
-            "validate_on_submit": True,
-        }
-        data.update({
-            key: value
-            for key, value in (
-                ("flair_id", flair_id),
-                ("flair_text", flair_text),
-                ("collection_id", collection_id),
-                ("discussion_type", discussion_type),
-                ("text", selftext),
-            )
-            if value is not None
-        })
-
-        data.update(
-            kind="videogif" if video.get("gif") else "video",
-            url=await video_media._upload(self._reddit, expected_mime_prefix="video"),
-            video_poster_url=await thumbnail_media._upload(self._reddit),
-        )
-        return await self._submit_media(data=data, timeout=timeout, without_websockets=without_websockets)
 
     async def subscribe(self, *, other_subreddits: list[asyncpraw.models.Subreddit] | None = None) -> None:
         """Subscribe to the subreddit.

--- a/asyncpraw/models/reddit/widgets.py
+++ b/asyncpraw/models/reddit/widgets.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
-from io import BytesIO
 from json import JSONEncoder, dumps
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
-
-import aiofiles
 
 from asyncpraw.const import API_PATH
 from asyncpraw.models.base import AsyncPRAWBase, DynamicAttributes
@@ -1845,10 +1841,10 @@ class SubredditWidgetsModeration:
         path = API_PATH["widget_order"].format(subreddit=self._subreddit, section=section)
         await self._reddit.patch(path, data={"json": dumps(order), "section": section})
 
-    async def upload_image(self, file_path: str) -> str:
+    async def upload_image(self, media: asyncpraw.models.WidgetMedia, /) -> str:
         """Upload an image to Reddit and get the URL.
 
-        :param file_path: The path to the local file.
+        :param media: The :class:`.WidgetMedia` to upload.
 
         :returns: The URL of the uploaded image as a ``str``.
 
@@ -1860,8 +1856,10 @@ class SubredditWidgetsModeration:
 
         .. code-block:: python
 
+            from asyncpraw.models import WidgetMedia
+
             my_sub = await reddit.subreddit("test")
-            image_url = await my_sub.widgets.mod.upload_image("/path/to/image.jpg")
+            image_url = await my_sub.widgets.mod.upload_image(WidgetMedia("/path/to/image.jpg"))
             image_data = [{"width": 300, "height": 300, "url": image_url, "linkUrl": ""}]
             styles = {"backgroundColor": "#FFFF66", "headerColor": "#3333EE"}
             await my_sub.widgets.mod.add_image_widget(
@@ -1869,27 +1867,4 @@ class SubredditWidgetsModeration:
             )
 
         """
-        file = Path(file_path)
-        img_data = {
-            "filepath": file.name,
-            "mimetype": "image/jpeg",
-        }
-        if file_path.lower().endswith(".png"):
-            img_data["mimetype"] = "image/png"
-
-        url = API_PATH["widget_lease"].format(subreddit=self._subreddit)
-        # until we learn otherwise, assume this request always succeeds
-        response = await self._reddit.post(url, data=img_data)
-        upload_lease = response["s3UploadLease"]
-        upload_data = {item["name"]: item["value"] for item in upload_lease["fields"]}
-        upload_url = f"https:{upload_lease['action']}"
-
-        assert self._reddit._core is not None
-        async with aiofiles.open(file, "rb") as image:
-            upload = BytesIO(await image.read())
-        upload.name = file.name
-        upload_data["file"] = upload
-        async with self._reddit._core.requestor.request("POST", upload_url, data=upload_data) as response:
-            response.raise_for_status()
-
-        return f"{upload_url}/{upload_data['key']}"
+        return await media._upload(self._subreddit)

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -36,6 +36,17 @@ them bound to an attribute of one of the Async PRAW models.
 
 .. toctree::
     :maxdepth: 2
+    :caption: Media
+
+    other/emojimedia
+    other/media
+    other/postmedia
+    other/stylesheetasset
+    other/stylesheetimage
+    other/widgetmedia
+
+.. toctree::
+    :maxdepth: 2
     :caption: ModNotes
 
     other/base_mod_notes

--- a/docs/code_overview/other/emojimedia.rst
+++ b/docs/code_overview/other/emojimedia.rst
@@ -1,0 +1,6 @@
+############
+ EmojiMedia
+############
+
+.. autoclass:: asyncpraw.models.EmojiMedia
+    :inherited-members:

--- a/docs/code_overview/other/media.rst
+++ b/docs/code_overview/other/media.rst
@@ -1,0 +1,6 @@
+#######
+ Media
+#######
+
+.. autoclass:: asyncpraw.models.Media
+    :inherited-members:

--- a/docs/code_overview/other/postmedia.rst
+++ b/docs/code_overview/other/postmedia.rst
@@ -1,0 +1,6 @@
+###########
+ PostMedia
+###########
+
+.. autoclass:: asyncpraw.models.PostMedia
+    :inherited-members:

--- a/docs/code_overview/other/stylesheetasset.rst
+++ b/docs/code_overview/other/stylesheetasset.rst
@@ -1,0 +1,6 @@
+#################
+ StylesheetAsset
+#################
+
+.. autoclass:: asyncpraw.models.StylesheetAsset
+    :inherited-members:

--- a/docs/code_overview/other/stylesheetimage.rst
+++ b/docs/code_overview/other/stylesheetimage.rst
@@ -1,0 +1,6 @@
+#################
+ StylesheetImage
+#################
+
+.. autoclass:: asyncpraw.models.StylesheetImage
+    :inherited-members:

--- a/docs/code_overview/other/widgetmedia.rst
+++ b/docs/code_overview/other/widgetmedia.rst
@@ -1,0 +1,6 @@
+#############
+ WidgetMedia
+#############
+
+.. autoclass:: asyncpraw.models.WidgetMedia
+    :inherited-members:

--- a/tests/integration/models/reddit/test_emoji.py
+++ b/tests/integration/models/reddit/test_emoji.py
@@ -1,7 +1,10 @@
+import pathlib
+
 import pytest
 
 from asyncpraw.exceptions import ClientException
 from asyncpraw.models import Emoji
+from asyncpraw.models.media import EmojiMedia
 
 from ... import IntegrationTest
 
@@ -57,8 +60,20 @@ class TestSubredditEmoji(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for extension in ["jpg", "png"]:
             emoji = await subreddit.emoji.add(
+                media=EmojiMedia(f"tests/integration/files/test.{extension}"),
                 name=f"test_{extension}",
-                image_path=f"tests/integration/files/test.{extension}",
+            )
+            assert isinstance(emoji, Emoji)
+
+    @pytest.mark.cassette_name("TestSubredditEmoji.test_add")
+    async def test_add__bytes(self, reddit):
+        reddit.read_only = False
+        subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
+        for extension in ["jpg", "png"]:
+            media_bytes = pathlib.Path(f"tests/integration/files/test.{extension}").read_bytes()
+            emoji = await subreddit.emoji.add(
+                media=EmojiMedia(media_bytes, name=f"test.{extension}"),
+                name=f"test_{extension}",
             )
             assert isinstance(emoji, Emoji)
 
@@ -67,9 +82,9 @@ class TestSubredditEmoji(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for extension in ["jpg", "png"]:
             emoji = await subreddit.emoji.add(
-                name=f"test_{extension}",
-                image_path=f"tests/integration/files/test.{extension}",
+                media=EmojiMedia(f"tests/integration/files/test.{extension}"),
                 mod_flair_only=True,
+                name=f"test_{extension}",
                 post_flair_allowed=True,
                 user_flair_allowed=False,
             )

--- a/tests/integration/models/reddit/test_submission.py
+++ b/tests/integration/models/reddit/test_submission.py
@@ -1,7 +1,7 @@
 import pytest
 
 from asyncpraw.exceptions import ClientException, RedditAPIException
-from asyncpraw.models import Comment, InlineGif, InlineImage, InlineVideo, Submission
+from asyncpraw.models import Comment, InlineGif, InlineImage, InlineVideo, PostMedia, Submission
 
 from ... import IntegrationTest
 
@@ -9,9 +9,9 @@ from ... import IntegrationTest
 class TestSubmission(IntegrationTest):
     @staticmethod
     def _inline_media(image_path):
-        gif = InlineGif(caption="optional caption", path=image_path("test.gif"))
-        image = InlineImage(caption="optional caption", path=image_path("test.png"))
-        video = InlineVideo(caption="optional caption", path=image_path("test.mp4"))
+        gif = InlineGif(caption="optional caption", media=PostMedia(image_path("test.gif")))
+        image = InlineImage(caption="optional caption", media=PostMedia(image_path("test.png")))
+        video = InlineVideo(caption="optional caption", media=PostMedia(image_path("test.mp4")))
         return {"gif1": gif, "image1": image, "video1": video}
 
     @staticmethod

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -28,8 +28,11 @@ from asyncpraw.models import (
     ModmailAction,
     ModmailConversation,
     ModmailMessage,
+    PostMedia,
     Redditor,
     Stylesheet,
+    StylesheetAsset,
+    StylesheetImage,
     Submission,
     Subreddit,
     WikiPage,
@@ -1004,21 +1007,21 @@ class TestSubredditStylesheet(IntegrationTest):
     async def test_upload(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        response = await subreddit.stylesheet.upload(name="asyncpraw", image_path=image_path("white-square.png"))
+        response = await subreddit.stylesheet.upload(StylesheetImage(image_path("white-square.png")), name="asyncpraw")
         assert response["img_src"].endswith(".png")
 
     async def test_upload__invalid(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         with pytest.raises(RedditAPIException) as excinfo:
-            await subreddit.stylesheet.upload(name="asyncpraw", image_path=image_path("invalid.jpg"))
+            await subreddit.stylesheet.upload(StylesheetImage(image_path("invalid.jpg")), name="asyncpraw")
         assert excinfo.value.items[0].error_type == "IMAGE_ERROR"
 
     async def test_upload__invalid_ext(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         with pytest.raises(RedditAPIException) as excinfo:
-            await subreddit.stylesheet.upload(name="asyncpraw", image_path=image_path("white-square.png"))
+            await subreddit.stylesheet.upload(StylesheetImage(image_path("white-square.png")), name="asyncpraw.png")
         assert excinfo.value.items[0].error_type == "BAD_CSS_NAME"
 
     async def test_upload__others_invalid(self, image_path, reddit):
@@ -1030,7 +1033,7 @@ class TestSubredditStylesheet(IntegrationTest):
             "upload_mobile_icon",
         ]:
             with pytest.raises(RedditAPIException) as excinfo:
-                await getattr(subreddit.stylesheet, method)(image_path("invalid.jpg"))
+                await getattr(subreddit.stylesheet, method)(StylesheetImage(image_path("invalid.jpg")))
             assert excinfo.value.items[0].error_type == "IMAGE_ERROR"
 
     async def test_upload__others_too_large(self, image_path, reddit):
@@ -1045,84 +1048,86 @@ class TestSubredditStylesheet(IntegrationTest):
                 await getattr(
                     subreddit.stylesheet,
                     method,
-                )(image_path("too_large.jpg"))
+                )(StylesheetImage(image_path("too_large.jpg")))
 
     async def test_upload__too_large(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         with pytest.raises(TooLarge):
-            await subreddit.stylesheet.upload(name="asyncpraw", image_path=image_path("too_large.jpg"))
+            await subreddit.stylesheet.upload(StylesheetImage(image_path("too_large.jpg")), name="asyncpraw")
 
     async def test_upload_banner__jpg(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        await subreddit.stylesheet.upload_banner(image_path("white-square.jpg"))
+        await subreddit.stylesheet.upload_banner(StylesheetAsset(image_path("white-square.jpg")))
 
     async def test_upload_banner__png(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        await subreddit.stylesheet.upload_banner(image_path("white-square.png"))
+        await subreddit.stylesheet.upload_banner(StylesheetAsset(image_path("white-square.png")))
 
     async def test_upload_banner_additional_image__align(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for alignment in ("left", "centered", "right"):
-            await subreddit.stylesheet.upload_banner_additional_image(image_path("white-square.png"), align=alignment)
+            await subreddit.stylesheet.upload_banner_additional_image(
+                StylesheetAsset(image_path("white-square.png")), align=alignment
+            )
 
     async def test_upload_banner_additional_image__jpg(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        await subreddit.stylesheet.upload_banner_additional_image(image_path("white-square.jpg"))
+        await subreddit.stylesheet.upload_banner_additional_image(StylesheetAsset(image_path("white-square.jpg")))
 
     async def test_upload_banner_additional_image__png(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        await subreddit.stylesheet.upload_banner_additional_image(image_path("white-square.png"))
+        await subreddit.stylesheet.upload_banner_additional_image(StylesheetAsset(image_path("white-square.png")))
 
     async def test_upload_banner_hover_image__jpg(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        await subreddit.stylesheet.upload_banner_additional_image(image_path("white-square.png"))
-        await subreddit.stylesheet.upload_banner_hover_image(image_path("white-square.jpg"))
+        await subreddit.stylesheet.upload_banner_additional_image(StylesheetAsset(image_path("white-square.png")))
+        await subreddit.stylesheet.upload_banner_hover_image(StylesheetAsset(image_path("white-square.jpg")))
 
     async def test_upload_banner_hover_image__png(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        await subreddit.stylesheet.upload_banner_additional_image(image_path("white-square.jpg"))
-        await subreddit.stylesheet.upload_banner_hover_image(image_path("white-square.png"))
+        await subreddit.stylesheet.upload_banner_additional_image(StylesheetAsset(image_path("white-square.jpg")))
+        await subreddit.stylesheet.upload_banner_hover_image(StylesheetAsset(image_path("white-square.png")))
 
     async def test_upload_header__jpg(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        response = await subreddit.stylesheet.upload_header(image_path("white-square.jpg"))
+        response = await subreddit.stylesheet.upload_header(StylesheetImage(image_path("white-square.jpg")))
         assert response["img_src"].endswith(".jpg")
 
     async def test_upload_header__png(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        response = await subreddit.stylesheet.upload_header(image_path("white-square.png"))
+        response = await subreddit.stylesheet.upload_header(StylesheetImage(image_path("white-square.png")))
         assert response["img_src"].endswith(".png")
 
     async def test_upload_mobile_banner__jpg(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        await subreddit.stylesheet.upload_mobile_banner(image_path("white-square.jpg"))
+        await subreddit.stylesheet.upload_mobile_banner(StylesheetAsset(image_path("white-square.jpg")))
 
     async def test_upload_mobile_banner__png(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        await subreddit.stylesheet.upload_mobile_banner(image_path("white-square.png"))
+        await subreddit.stylesheet.upload_mobile_banner(StylesheetAsset(image_path("white-square.png")))
 
     async def test_upload_mobile_header(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        response = await subreddit.stylesheet.upload_mobile_header(image_path("header.jpg"))
+        response = await subreddit.stylesheet.upload_mobile_header(StylesheetImage(image_path("header.jpg")))
         assert response["img_src"].endswith(".jpg")
 
     async def test_upload_mobile_icon(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        response = await subreddit.stylesheet.upload_mobile_icon(image_path("icon.jpg"))
+        response = await subreddit.stylesheet.upload_mobile_icon(StylesheetImage(image_path("icon.jpg")))
         assert response["img_src"].endswith(".jpg")
 
 
@@ -1327,9 +1332,9 @@ class TestSubreddit(IntegrationTest):
     async def test_submit__selftext_inline_media(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        gif = InlineGif(caption="optional caption", path=image_path("test.gif"))
-        image = InlineImage(caption="optional caption", path=image_path("test.png"))
-        video = InlineVideo(caption="optional caption", path=image_path("test.mp4"))
+        gif = InlineGif(caption="optional caption", media=PostMedia(image_path("test.gif")))
+        image = InlineImage(caption="optional caption", media=PostMedia(image_path("test.png")))
+        video = InlineVideo(caption="optional caption", media=PostMedia(image_path("test.mp4")))
         selftext = "Text with a gif {gif1} an image {image1} and a video {video1} inline"
         media = {"gif1": gif, "image1": image, "video1": video}
         submission = await subreddit.submit("title", inline_media=media, selftext=selftext)
@@ -1385,14 +1390,14 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         images = [
-            {"image_path": image_path("test.png")},
-            {"image_path": image_path("test.jpg"), "caption": "test.jpg"},
+            {"media": PostMedia(image_path("test.png"))},
+            {"media": PostMedia(image_path("test.jpg")), "caption": "test.jpg"},
             {
-                "image_path": image_path("test.gif"),
+                "media": PostMedia(image_path("test.gif")),
                 "outbound_url": "https://example.com",
             },
             {
-                "image_path": image_path("test.png"),
+                "media": PostMedia(image_path("test.png")),
                 "caption": "test.png",
                 "outbound_url": "https://example.com",
             },
@@ -1406,7 +1411,7 @@ class TestSubreddit(IntegrationTest):
         assert isinstance(submission.gallery_data["items"], list)
         for i, item in enumerate(items):
             test_data = images[i]
-            test_data.pop("image_path")
+            test_data.pop("media")
             item.pop("id")
             item.pop("media_id")
             assert item == test_data
@@ -1415,14 +1420,14 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         images = [
-            {"image_path": image_path("test.png")},
-            {"image_path": image_path("test.jpg"), "caption": "test.jpg"},
+            {"media": PostMedia(image_path("test.png"))},
+            {"media": PostMedia(image_path("test.jpg")), "caption": "test.jpg"},
             {
-                "image_path": image_path("test.gif"),
+                "media": PostMedia(image_path("test.gif")),
                 "outbound_url": "https://example.com",
             },
             {
-                "image_path": image_path("test.png"),
+                "media": PostMedia(image_path("test.png")),
                 "caption": "test.png",
                 "outbound_url": "https://example.com",
             },
@@ -1438,14 +1443,14 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         images = [
-            {"image_path": image_path("test.png")},
-            {"image_path": image_path("test.jpg"), "caption": "test.jpg"},
+            {"media": PostMedia(image_path("test.png"))},
+            {"media": PostMedia(image_path("test.jpg")), "caption": "test.jpg"},
             {
-                "image_path": image_path("test.gif"),
+                "media": PostMedia(image_path("test.gif")),
                 "outbound_url": "https://example.com",
             },
             {
-                "image_path": image_path("test.png"),
+                "media": PostMedia(image_path("test.png")),
                 "caption": "test.png",
                 "outbound_url": "https://example.com",
             },
@@ -1462,17 +1467,17 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         images = [
-            {"image_path": image_path("test.png")},
+            {"media": PostMedia(image_path("test.png"))},
             {
-                "image_path": image_path("test.jpg"),
+                "media": PostMedia(image_path("test.jpg")),
                 "caption": "A JPG image.",
             },
             {
-                "image_path": image_path("test.gif"),
+                "media": PostMedia(image_path("test.gif")),
                 "outbound_url": "https://example.com",
             },
             {
-                "image_path": image_path("test.png"),
+                "media": PostMedia(image_path("test.png")),
                 "caption": "A PNG image.",
                 "outbound_url": "https://example.com",
             },
@@ -1488,7 +1493,7 @@ class TestSubreddit(IntegrationTest):
         assert isinstance(submission.gallery_data["items"], list)
         for i, item in enumerate(items):
             test_data = images[i]
-            test_data.pop("image_path")
+            test_data.pop("media")
             item.pop("id")
             item.pop("media_id")
             assert item == test_data
@@ -1508,7 +1513,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for i, file_name in enumerate(("test.png", "test.jpg", "test.gif")):
             image = image_path(file_name)
-            submission = await subreddit.submit_image(f"Test Title {i}", image)
+            submission = await subreddit.submit_image(f"Test Title {i}", PostMedia(image))
             await submission.load()
             assert submission.author == pytest.placeholders.username
             assert submission.is_reddit_media_domain
@@ -1525,7 +1530,7 @@ class TestSubreddit(IntegrationTest):
         for file_name in ("test.png", "test.jpg"):
             image = image_path(file_name)
             with pytest.raises(ClientException):
-                await subreddit.submit_image("Test Title", image)
+                await subreddit.submit_image("Test Title", PostMedia(image))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1538,7 +1543,9 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
-        submission = await subreddit.submit_image("Test Title", image, flair_id=flair_id, flair_text=flair_text)
+        submission = await subreddit.submit_image(
+            "Test Title", PostMedia(image), flair_id=flair_id, flair_text=flair_text
+        )
         await submission.load()
         assert submission.link_flair_css_class == flair_class
         assert submission.link_flair_text == flair_text
@@ -1563,7 +1570,7 @@ class TestSubreddit(IntegrationTest):
             if "https://reddit-uploaded-media.s3-accelerate.amazonaws.com" in url:
                 response = MagicMock(spec=ClientResponse)
                 response.__aenter__.return_value.text = AsyncMock(return_value=mock_data)
-                response.status = 400
+                response.__aenter__.return_value.ok = False
                 return response
             return _request(method, url, *args, **kwargs)
 
@@ -1574,7 +1581,7 @@ class TestSubreddit(IntegrationTest):
             tempfile.write(fake_png)
         with pytest.raises(TooLargeMediaException):
             subreddit = await reddit.subreddit("test")
-            await subreddit.submit_image("test", tempfile.name)
+            await subreddit.submit_image("test", PostMedia(tempfile.name))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1586,7 +1593,7 @@ class TestSubreddit(IntegrationTest):
         image = image_path("test.png")
         selftext = "Testing **Async PRAW** image submission *with markdown selftext*."
         title = "Testing Async PRAW image submission with selftext"
-        submission = await subreddit.submit_image(title, image, selftext=selftext)
+        submission = await subreddit.submit_image(title, PostMedia(image), selftext=selftext)
         assert submission.selftext == selftext
         assert submission.is_reddit_media_domain
         assert submission.title == title
@@ -1601,7 +1608,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_image("Test Title", image)
+            await subreddit.submit_image("Test Title", PostMedia(image))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1616,7 +1623,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_image("Test Title", image)
+            await subreddit.submit_image("Test Title", PostMedia(image))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1631,7 +1638,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_image("Test Title", image)
+            await subreddit.submit_image("Test Title", PostMedia(image))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1646,14 +1653,14 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_image("Test Title", image)
+            await subreddit.submit_image("Test Title", PostMedia(image))
 
     async def test_submit_image__without_websockets(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.png", "test.jpg", "test.gif"):
             image = image_path(file_name)
-            submission = await subreddit.submit_image("Test Title", image, without_websockets=True)
+            submission = await subreddit.submit_image("Test Title", PostMedia(image), without_websockets=True)
             assert submission is None
 
     @mock.patch(
@@ -1664,7 +1671,7 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
-        submission = await subreddit.submit_image("Test Title", image, discussion_type="CHAT")
+        submission = await subreddit.submit_image("Test Title", PostMedia(image), discussion_type="CHAT")
         await submission.load()
         assert submission.discussion_type == "CHAT"
 
@@ -1674,7 +1681,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises((RedditAPIException, BadRequest)):  # waiting for prawcore fix
-            await subreddit.submit_image("gdfgfdgdgdgfgfdgdfgfdgfdg", image, without_websockets=True)
+            await subreddit.submit_image("gdfgfdgdgdgfgfdgdfgfdgfdg", PostMedia(image), without_websockets=True)
 
     async def test_submit_live_chat(self, reddit):
         reddit.read_only = False
@@ -1739,7 +1746,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for i, file_name in enumerate(("test.mov", "test.mp4")):
             video = image_path(file_name)
-            submission = await subreddit.submit_video(f"Test Title {i}", video)
+            submission = await subreddit.submit_video(f"Test Title {i}", PostMedia(video))
             await submission.load()
             assert submission.author == pytest.placeholders.username
             # assert submission.is_reddit_media_domain
@@ -1757,7 +1764,7 @@ class TestSubreddit(IntegrationTest):
         for file_name in ("test.mov", "test.mp4"):
             video = image_path(file_name)
             with pytest.raises(ClientException):
-                await subreddit.submit_video("Test Title", video)
+                await subreddit.submit_video("Test Title", PostMedia(video))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1770,7 +1777,9 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
-        submission = await subreddit.submit_video("Test Title", video, flair_id=flair_id, flair_text=flair_text)
+        submission = await subreddit.submit_video(
+            "Test Title", PostMedia(video), flair_id=flair_id, flair_text=flair_text
+        )
         assert submission.link_flair_css_class == flair_class
         assert submission.link_flair_text == flair_text
 
@@ -1787,7 +1796,7 @@ class TestSubreddit(IntegrationTest):
             title = f"Test Title {i}"
             selftext = "Testing **Async PRAW** video submission *with markdown selftext*."
             video = image_path(file_name)
-            submission = await subreddit.submit_video(title, video, selftext=selftext)
+            submission = await subreddit.submit_video(title, PostMedia(video), selftext=selftext)
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
             assert submission.title == title
@@ -1808,7 +1817,9 @@ class TestSubreddit(IntegrationTest):
         ):
             video = image_path(video_name)
             thumb = image_path(thumb_name)
-            submission = await subreddit.submit_video("Test Title", video, thumbnail_path=thumb)
+            submission = await subreddit.submit_video(
+                "Test Title", {"media": PostMedia(video), "thumbnail": PostMedia(thumb)}
+            )
             await submission.load()
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
@@ -1824,7 +1835,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_video("Test Title", video)
+            await subreddit.submit_video("Test Title", PostMedia(video))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1839,7 +1850,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_video("Test Title", video)
+            await subreddit.submit_video("Test Title", PostMedia(video))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1854,7 +1865,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_video("Test Title", video)
+            await subreddit.submit_video("Test Title", PostMedia(video))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1869,7 +1880,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_video("Test Title", video)
+            await subreddit.submit_video("Test Title", PostMedia(video))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1882,7 +1893,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.mov", "test.mp4"):
             video = image_path(file_name)
-            submission = await subreddit.submit_video("Test Title", video, videogif=True)
+            submission = await subreddit.submit_video("Test Title", {"gif": True, "media": PostMedia(video)})
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
             assert submission.title == "Test Title"
@@ -1892,7 +1903,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.mov", "test.mp4"):
             video = image_path(file_name)
-            submission = await subreddit.submit_video("Test Title", video, without_websockets=True)
+            submission = await subreddit.submit_video("Test Title", PostMedia(video), without_websockets=True)
             assert submission is None
 
     @mock.patch(
@@ -1903,7 +1914,7 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
-        submission = await subreddit.submit_video("Test Title", video, discussion_type="CHAT")
+        submission = await subreddit.submit_video("Test Title", PostMedia(video), discussion_type="CHAT")
         await submission.load()
         assert submission.discussion_type == "CHAT"
 
@@ -1913,7 +1924,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises((RedditAPIException, BadRequest)):  # waiting for prawcore fix
-            await subreddit.submit_video("gdfgfdgdgdgfgfdgdfgfdgfdg", video, without_websockets=True)
+            await subreddit.submit_video("gdfgfdgdgdgfgfdgdfgfdgfdg", PostMedia(video), without_websockets=True)
 
     async def test_subscribe(self, reddit):
         reddit.read_only = False

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -1403,7 +1403,7 @@ class TestSubreddit(IntegrationTest):
             },
         ]
 
-        submission = await subreddit.submit_gallery("Test Title", images)
+        submission = await subreddit.submit("Test Title", gallery=images)
         assert submission.author == pytest.placeholders.username
         assert submission.is_gallery
         assert submission.title == "Test Title"
@@ -1434,7 +1434,7 @@ class TestSubreddit(IntegrationTest):
         ]
 
         with pytest.raises(RedditAPIException):
-            await subreddit.submit_gallery("Test Title", images)
+            await subreddit.submit("Test Title", gallery=images)
 
     async def test_submit_gallery__flair(self, image_path, reddit):
         flair_id = "6fc213da-cae7-11ea-9274-0e2407099e45"
@@ -1455,7 +1455,12 @@ class TestSubreddit(IntegrationTest):
                 "outbound_url": "https://example.com",
             },
         ]
-        submission = await subreddit.submit_gallery("Test Title", images, flair_id=flair_id, flair_text=flair_text)
+        submission = await subreddit.submit(
+            "Test Title",
+            flair_id=flair_id,
+            flair_text=flair_text,
+            gallery=images,
+        )
         assert submission.link_flair_css_class == flair_class
         assert submission.link_flair_text == flair_text
 
@@ -1484,7 +1489,7 @@ class TestSubreddit(IntegrationTest):
         ]
         selftext = "Testing **Async PRAW** gallery submission *with markdown selftext*."
         title = "Testing Async PRAW Gallery with Selftext"
-        submission = await subreddit.submit_gallery(title, images, selftext=selftext)
+        submission = await subreddit.submit(title, gallery=images, selftext=selftext)
         assert submission.author == pytest.placeholders.username
         assert submission.is_gallery
         assert submission.title == title
@@ -1513,7 +1518,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for i, file_name in enumerate(("test.png", "test.jpg", "test.gif")):
             image = image_path(file_name)
-            submission = await subreddit.submit_image(f"Test Title {i}", PostMedia(image))
+            submission = await subreddit.submit(f"Test Title {i}", image=PostMedia(image))
             await submission.load()
             assert submission.author == pytest.placeholders.username
             assert submission.is_reddit_media_domain
@@ -1530,7 +1535,7 @@ class TestSubreddit(IntegrationTest):
         for file_name in ("test.png", "test.jpg"):
             image = image_path(file_name)
             with pytest.raises(ClientException):
-                await subreddit.submit_image("Test Title", PostMedia(image))
+                await subreddit.submit("Test Title", image=PostMedia(image))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1543,8 +1548,11 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
-        submission = await subreddit.submit_image(
-            "Test Title", PostMedia(image), flair_id=flair_id, flair_text=flair_text
+        submission = await subreddit.submit(
+            "Test Title",
+            flair_id=flair_id,
+            flair_text=flair_text,
+            image=PostMedia(image),
         )
         await submission.load()
         assert submission.link_flair_css_class == flair_class
@@ -1581,7 +1589,7 @@ class TestSubreddit(IntegrationTest):
             tempfile.write(fake_png)
         with pytest.raises(TooLargeMediaException):
             subreddit = await reddit.subreddit("test")
-            await subreddit.submit_image("test", PostMedia(tempfile.name))
+            await subreddit.submit("test", image=PostMedia(tempfile.name))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1593,7 +1601,7 @@ class TestSubreddit(IntegrationTest):
         image = image_path("test.png")
         selftext = "Testing **Async PRAW** image submission *with markdown selftext*."
         title = "Testing Async PRAW image submission with selftext"
-        submission = await subreddit.submit_image(title, PostMedia(image), selftext=selftext)
+        submission = await subreddit.submit(title, image=PostMedia(image), selftext=selftext)
         assert submission.selftext == selftext
         assert submission.is_reddit_media_domain
         assert submission.title == title
@@ -1608,7 +1616,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_image("Test Title", PostMedia(image))
+            await subreddit.submit("Test Title", image=PostMedia(image))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1623,7 +1631,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_image("Test Title", PostMedia(image))
+            await subreddit.submit("Test Title", image=PostMedia(image))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1638,7 +1646,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_image("Test Title", PostMedia(image))
+            await subreddit.submit("Test Title", image=PostMedia(image))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1653,14 +1661,18 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_image("Test Title", PostMedia(image))
+            await subreddit.submit("Test Title", image=PostMedia(image))
 
     async def test_submit_image__without_websockets(self, image_path, reddit):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.png", "test.jpg", "test.gif"):
             image = image_path(file_name)
-            submission = await subreddit.submit_image("Test Title", PostMedia(image), without_websockets=True)
+            submission = await subreddit.submit(
+                "Test Title",
+                image=PostMedia(image),
+                without_websockets=True,
+            )
             assert submission is None
 
     @mock.patch(
@@ -1671,7 +1683,7 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
-        submission = await subreddit.submit_image("Test Title", PostMedia(image), discussion_type="CHAT")
+        submission = await subreddit.submit("Test Title", discussion_type="CHAT", image=PostMedia(image))
         await submission.load()
         assert submission.discussion_type == "CHAT"
 
@@ -1681,7 +1693,11 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises((RedditAPIException, BadRequest)):  # waiting for prawcore fix
-            await subreddit.submit_image("gdfgfdgdgdgfgfdgdfgfdgfdg", PostMedia(image), without_websockets=True)
+            await subreddit.submit(
+                "gdfgfdgdgdgfgfdgdfgfdgfdg",
+                image=PostMedia(image),
+                without_websockets=True,
+            )
 
     async def test_submit_live_chat(self, reddit):
         reddit.read_only = False
@@ -1694,7 +1710,9 @@ class TestSubreddit(IntegrationTest):
         options = ["Yes", "No", "3", "4", "5", "6"]
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        submission = await subreddit.submit_poll("Test Poll", duration=6, options=options, selftext="Test poll text.")
+        submission = await subreddit.submit(
+            "Test Poll", poll={"duration": 6, "options": options}, selftext="Test poll text."
+        )
         await submission.load()
         assert submission.author == pytest.placeholders.username
         assert submission.selftext.startswith("Test poll text.")
@@ -1709,12 +1727,11 @@ class TestSubreddit(IntegrationTest):
         options = ["Yes", "No"]
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        submission = await subreddit.submit_poll(
+        submission = await subreddit.submit(
             "Test Poll",
-            duration=6,
             flair_id=flair_id,
             flair_text=flair_text,
-            options=options,
+            poll={"duration": 6, "options": options},
             selftext="Test poll text.",
         )
         await submission.load()
@@ -1725,11 +1742,10 @@ class TestSubreddit(IntegrationTest):
         options = ["Yes", "No"]
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
-        submission = await subreddit.submit_poll(
+        submission = await subreddit.submit(
             "Test Poll",
             discussion_type="CHAT",
-            duration=2,
-            options=options,
+            poll={"duration": 2, "options": options},
             selftext="",
         )
         await submission.load()
@@ -1746,7 +1762,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for i, file_name in enumerate(("test.mov", "test.mp4")):
             video = image_path(file_name)
-            submission = await subreddit.submit_video(f"Test Title {i}", PostMedia(video))
+            submission = await subreddit.submit(f"Test Title {i}", video=PostMedia(video))
             await submission.load()
             assert submission.author == pytest.placeholders.username
             # assert submission.is_reddit_media_domain
@@ -1764,7 +1780,7 @@ class TestSubreddit(IntegrationTest):
         for file_name in ("test.mov", "test.mp4"):
             video = image_path(file_name)
             with pytest.raises(ClientException):
-                await subreddit.submit_video("Test Title", PostMedia(video))
+                await subreddit.submit("Test Title", video=PostMedia(video))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1777,8 +1793,11 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
-        submission = await subreddit.submit_video(
-            "Test Title", PostMedia(video), flair_id=flair_id, flair_text=flair_text
+        submission = await subreddit.submit(
+            "Test Title",
+            flair_id=flair_id,
+            flair_text=flair_text,
+            video=PostMedia(video),
         )
         assert submission.link_flair_css_class == flair_class
         assert submission.link_flair_text == flair_text
@@ -1796,7 +1815,7 @@ class TestSubreddit(IntegrationTest):
             title = f"Test Title {i}"
             selftext = "Testing **Async PRAW** video submission *with markdown selftext*."
             video = image_path(file_name)
-            submission = await subreddit.submit_video(title, PostMedia(video), selftext=selftext)
+            submission = await subreddit.submit(title, selftext=selftext, video=PostMedia(video))
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
             assert submission.title == title
@@ -1817,8 +1836,9 @@ class TestSubreddit(IntegrationTest):
         ):
             video = image_path(video_name)
             thumb = image_path(thumb_name)
-            submission = await subreddit.submit_video(
-                "Test Title", {"media": PostMedia(video), "thumbnail": PostMedia(thumb)}
+            submission = await subreddit.submit(
+                "Test Title",
+                video={"media": PostMedia(video), "thumbnail": PostMedia(thumb)},
             )
             await submission.load()
             assert submission.author == pytest.placeholders.username
@@ -1835,7 +1855,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_video("Test Title", PostMedia(video))
+            await subreddit.submit("Test Title", video=PostMedia(video))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1850,7 +1870,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_video("Test Title", PostMedia(video))
+            await subreddit.submit("Test Title", video=PostMedia(video))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1865,7 +1885,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_video("Test Title", PostMedia(video))
+            await subreddit.submit("Test Title", video=PostMedia(video))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1880,7 +1900,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            await subreddit.submit_video("Test Title", PostMedia(video))
+            await subreddit.submit("Test Title", video=PostMedia(video))
 
     @mock.patch(
         "aiohttp.client.ClientSession.ws_connect",
@@ -1893,7 +1913,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.mov", "test.mp4"):
             video = image_path(file_name)
-            submission = await subreddit.submit_video("Test Title", {"gif": True, "media": PostMedia(video)})
+            submission = await subreddit.submit("Test Title", video={"gif": True, "media": PostMedia(video)})
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
             assert submission.title == "Test Title"
@@ -1903,7 +1923,11 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.mov", "test.mp4"):
             video = image_path(file_name)
-            submission = await subreddit.submit_video("Test Title", PostMedia(video), without_websockets=True)
+            submission = await subreddit.submit(
+                "Test Title",
+                video=PostMedia(video),
+                without_websockets=True,
+            )
             assert submission is None
 
     @mock.patch(
@@ -1914,7 +1938,7 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
-        submission = await subreddit.submit_video("Test Title", PostMedia(video), discussion_type="CHAT")
+        submission = await subreddit.submit("Test Title", discussion_type="CHAT", video=PostMedia(video))
         await submission.load()
         assert submission.discussion_type == "CHAT"
 
@@ -1924,7 +1948,11 @@ class TestSubreddit(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises((RedditAPIException, BadRequest)):  # waiting for prawcore fix
-            await subreddit.submit_video("gdfgfdgdgdgfgfdgdfgfdgfdg", PostMedia(video), without_websockets=True)
+            await subreddit.submit(
+                "gdfgfdgdgdgfgfdgdfgfdgfdg",
+                video=PostMedia(video),
+                without_websockets=True,
+            )
 
     async def test_subscribe(self, reddit):
         reddit.read_only = False

--- a/tests/integration/models/reddit/test_widgets.py
+++ b/tests/integration/models/reddit/test_widgets.py
@@ -20,6 +20,7 @@ from asyncpraw.models import (
     Subreddit,
     TextArea,
     Widget,
+    WidgetMedia,
 )
 
 from ... import IntegrationTest
@@ -54,7 +55,7 @@ class TestButtonWidget(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         widgets = subreddit.widgets
         styles = {"headerColor": "#123456", "backgroundColor": "#bb0e00"}
-        my_image = await widgets.mod.upload_image(image_path("test.png"))
+        my_image = await widgets.mod.upload_image(WidgetMedia(image_path("test.png")))
         buttons = [
             {
                 "kind": "text",
@@ -294,7 +295,7 @@ class TestCustomWidget(IntegrationTest):
                 "width": 0,
                 "height": 0,
                 "name": "a",
-                "url": await widgets.mod.upload_image(image_path("test.png")),
+                "url": await widgets.mod.upload_image(WidgetMedia(image_path("test.png"))),
             }
         ]
 
@@ -415,7 +416,7 @@ class TestImageWidget(IntegrationTest):
                 "width": 10,
                 "height": 10,
                 "linkUrl": "",
-                "url": await widgets.mod.upload_image(img_path),
+                "url": await widgets.mod.upload_image(WidgetMedia(img_path)),
             }
             for img_path in image_paths
         ]
@@ -792,7 +793,7 @@ class TestSubredditWidgetsModeration(IntegrationTest):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         widgets = subreddit.widgets
         for image in ("test.jpg", "test.png"):
-            image_url = await widgets.mod.upload_image(image_path(image))
+            image_url = await widgets.mod.upload_image(WidgetMedia(image_path(image)))
             assert image_url
 
 

--- a/tests/integration/models/reddit/test_wikipage.py
+++ b/tests/integration/models/reddit/test_wikipage.py
@@ -5,7 +5,7 @@ import pytest
 from asyncprawcore import Forbidden, NotFound
 
 from asyncpraw.exceptions import RedditAPIException
-from asyncpraw.models import Redditor, WikiPage
+from asyncpraw.models import Redditor, StylesheetImage, WikiPage
 
 from ... import IntegrationTest
 
@@ -44,8 +44,8 @@ class TestWikiPageModeration(IntegrationTest):
         reddit.read_only = False
         page = await subreddit.wiki.get_page("config/stylesheet")
         await subreddit.stylesheet.upload(
+            StylesheetImage("tests/integration/files/icon.jpg"),
             name="css-revert-fail",
-            image_path="tests/integration/files/icon.jpg",
         )
         await page.edit(content="div {background: url(%%css-revert-fail%%)}")
         revision_id = (await self.async_next(page.revisions(limit=1)))["id"]

--- a/tests/unit/models/reddit/test_inline_media.py
+++ b/tests/unit/models/reddit/test_inline_media.py
@@ -1,17 +1,17 @@
 import pickle
 
-from asyncpraw.models import InlineGif, InlineImage, InlineMedia, InlineVideo
+from asyncpraw.models import InlineGif, InlineImage, InlineMedia, InlineVideo, PostMedia
 
 from ... import UnitTest
 
 
 class TestInlineMedia(UnitTest):
     def test_equality(self):
-        media1 = InlineMedia(path="path1", caption="caption1")
+        media1 = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
         media1.media_id = "media_id1"
-        media2 = InlineMedia(path="path1", caption="caption1")
+        media2 = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
         media2.media_id = "media_id1"
-        media3 = InlineMedia(path="path2", caption="caption2")
+        media3 = InlineMedia(caption="caption2", media=PostMedia(b"data2", name="name2"))
         media3.media_id = "media_id2"
         assert media1 == media1
         assert media2 == media2
@@ -21,11 +21,11 @@ class TestInlineMedia(UnitTest):
         assert media1 != media3
 
     def test_hash(self):
-        media1 = InlineMedia(path="path1", caption="caption1")
+        media1 = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
         media1.media_id = "media_id1"
-        media2 = InlineMedia(path="path1", caption="caption1")
+        media2 = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
         media2.media_id = "media_id1"
-        media3 = InlineMedia(path="path2", caption="caption2")
+        media3 = InlineMedia(caption="caption2", media=PostMedia(b"data2", name="name2"))
         media3.media_id = "media_id2"
         assert hash(media1) == hash(media1)
         assert hash(media2) == hash(media2)
@@ -35,17 +35,17 @@ class TestInlineMedia(UnitTest):
         assert hash(media1) != hash(media3)
 
     def test_pickle(self):
-        media = InlineMedia(path="path1", caption="caption1")
+        media = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
         for level in range(pickle.HIGHEST_PROTOCOL + 1):
             other = pickle.loads(pickle.dumps(media, protocol=level))
             assert media == other
 
     def test_repr(self):
-        media = InlineMedia(path="path1", caption="caption1")
-        no_caption = InlineMedia(path="path1")
-        gif = InlineGif(path="gif_path1", caption="gif_caption1")
-        image = InlineImage(path="image_path1", caption="image_caption1")
-        video = InlineVideo(path="video_path1", caption="video_caption1")
+        media = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
+        no_caption = InlineMedia(media=PostMedia(b"data1", name="name1"))
+        gif = InlineGif(caption="gif_caption1", media=PostMedia(b"gif_data1", name="gif_name1"))
+        image = InlineImage(caption="image_caption1", media=PostMedia(b"image_data1", name="image_name1"))
+        video = InlineVideo(caption="video_caption1", media=PostMedia(b"video_data1", name="video_name1"))
         assert repr(media) == "<InlineMedia caption='caption1'>"
         assert repr(no_caption) == "<InlineMedia caption=None>"
         assert repr(gif) == "<InlineGif caption='gif_caption1'>"
@@ -53,11 +53,11 @@ class TestInlineMedia(UnitTest):
         assert repr(video) == "<InlineVideo caption='video_caption1'>"
 
     def test_str(self):
-        media = InlineMedia(path="path1", caption="caption1")
-        no_caption = InlineMedia(path="path1")
-        gif = InlineGif(path="gif_path1", caption="gif_caption1")
-        image = InlineImage(path="image_path1", caption="image_caption1")
-        video = InlineVideo(path="video_path1", caption="video_caption1")
+        media = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
+        no_caption = InlineMedia(media=PostMedia(b"data1", name="name1"))
+        gif = InlineGif(caption="gif_caption1", media=PostMedia(b"gif_data1", name="gif_name1"))
+        image = InlineImage(caption="image_caption1", media=PostMedia(b"image_data1", name="image_name1"))
+        video = InlineVideo(caption="video_caption1", media=PostMedia(b"video_data1", name="video_name1"))
         media.media_id = "media_media_id"
         no_caption.media_id = "media_media_id_no_caption"
         gif.media_id = "gif_media_id"

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -7,7 +7,7 @@ import pytest
 from aiohttp import ClientResponse
 
 from asyncpraw.exceptions import ClientException, MediaPostFailed
-from asyncpraw.models import InlineGif, InlineImage, InlineVideo, PostMedia, Subreddit, WikiPage
+from asyncpraw.models import InlineGif, InlineImage, InlineVideo, PostMedia, StylesheetAsset, Subreddit, WikiPage
 from asyncpraw.models.reddit.subreddit import SubredditFlairTemplates
 
 from ... import UnitTest
@@ -73,7 +73,7 @@ class TestSubreddit(UnitTest):
         connection_mock.return_value = context_manager
 
         with pytest.raises(MediaPostFailed):
-            await Subreddit(reddit, display_name="test").submit_image("Test", PostMedia(b"", name="dummy.png"))
+            await Subreddit(reddit, display_name="test").submit("Test", image=PostMedia(b"", name="dummy.png"))
         await reddit._core.requestor._http.close()
 
     @mock.patch("aiohttp.client.ClientSession.ws_connect", new=AsyncMock())
@@ -95,7 +95,7 @@ class TestSubreddit(UnitTest):
         response.status = 500
         mock_method.side_effect = ServerError(response=response)
         with pytest.raises(ServerError):
-            await Subreddit(reddit, display_name="test").submit_image("Test", PostMedia(b"", name="test.png"))
+            await Subreddit(reddit, display_name="test").submit("Test", image=PostMedia(b"", name="test.png"))
 
     async def test_notes_delete__invalid_args(self):
         with pytest.raises(TypeError) as excinfo:
@@ -127,17 +127,29 @@ class TestSubreddit(UnitTest):
         assert str(subreddit) == "name"
 
     async def test_submit__failure(self, reddit):
-        message = "Either 'selftext' and/or 'url' must be provided."
+        message = "At least one of 'gallery', 'image', 'poll', 'selftext', 'url', or 'video' must be provided."
         subreddit = Subreddit(reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
             await subreddit.submit("Cool title")
         assert str(excinfo.value) == message
 
+    async def test_submit__multiple_kinds_disallowed(self, reddit):
+        message = "Only one of 'gallery', 'image', 'poll', 'url', or 'video' can be provided ('image', 'url' given)."
+        subreddit = Subreddit(reddit, display_name="name")
+
+        with pytest.raises(TypeError) as excinfo:
+            await subreddit.submit(
+                "Cool title",
+                image=PostMedia(b"", name="test.png"),
+                url="https://praw.readthedocs.org/en/stable/",
+            )
+        assert str(excinfo.value) == message
+
     async def test_submit__url_selftext_inline_media_disallowed(self, reddit):
         # `selftext` and `url` are no longer mutually exclusive,
         # but `inline_media` is not supported for link post selftext
-        message = "As of 2025-10-08, `inline_media` is not supported for link post selftext. Only Markdown text can be added to non-self posts."
+        message = "'inline_media' is only supported for text submissions. Only Markdown text can be used for the selftext of a 'url' submission."
         subreddit = Subreddit(reddit, display_name="name")
         gif = InlineGif(caption="optional caption", media=PostMedia(b"", name="test.gif"))
         image = InlineImage(caption="optional caption", media=PostMedia(b"", name="test.png"))
@@ -155,7 +167,7 @@ class TestSubreddit(UnitTest):
         subreddit = Subreddit(reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            await subreddit.submit_gallery("Cool title", [{"media": "a string is not PostMedia"}])
+            await subreddit.submit("Cool title", gallery=[{"media": "a string is not PostMedia"}])
         assert str(excinfo.value) == message
 
     async def test_submit_gallery__missing_media(self, reddit):
@@ -163,7 +175,7 @@ class TestSubreddit(UnitTest):
         subreddit = Subreddit(reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            await subreddit.submit_gallery("Cool title", [{"caption": "caption"}, {"caption": "caption2"}])
+            await subreddit.submit("Cool title", gallery=[{"caption": "caption"}, {"caption": "caption2"}])
         assert str(excinfo.value) == message
 
     async def test_submit_gallery__too_long_caption(self, reddit):
@@ -175,8 +187,9 @@ class TestSubreddit(UnitTest):
             "yyyyyyyyyyyyyyyy too long caption"
         )
         with pytest.raises(TypeError) as excinfo:
-            await subreddit.submit_gallery(
-                "Cool title", [{"media": PostMedia(b"", name="test.png"), "caption": caption}]
+            await subreddit.submit(
+                "Cool title",
+                gallery=[{"media": PostMedia(b"", name="test.png"), "caption": caption}],
             )
         assert str(excinfo.value) == message
 
@@ -185,7 +198,7 @@ class TestSubreddit(UnitTest):
         for file_name in ("test.mov", "test.mp4"):
             image = PostMedia(image_path(file_name))
             with pytest.raises(ClientException):
-                await subreddit.submit_image("Test Title", image)
+                await subreddit.submit("Test Title", image=image)
 
     async def test_submit_inline_media__invalid_media(self, reddit):
         message = "'media' must be a PostMedia instance."
@@ -199,32 +212,54 @@ class TestSubreddit(UnitTest):
             await subreddit.submit("title", inline_media=media, selftext=selftext)
         assert str(excinfo.value) == message
 
+    async def test_submit_poll__invalid_keys(self, reddit):
+        message = "'poll' contains invalid keys: 'duratoin'."
+        subreddit = Subreddit(reddit, display_name="name")
+
+        with pytest.raises(TypeError) as excinfo:
+            await subreddit.submit("Cool title", poll={"duratoin": 3, "options": ["Yes", "No"]})
+        assert str(excinfo.value) == message
+
+    async def test_submit_poll__missing_keys(self, reddit):
+        message = "'poll' is missing required keys: 'duration'."
+        subreddit = Subreddit(reddit, display_name="name")
+
+        with pytest.raises(TypeError) as excinfo:
+            await subreddit.submit("Cool title", poll={"options": ["Yes", "No"]})
+        assert str(excinfo.value) == message
+
     async def test_submit_video__bad_filetype(self, image_path, reddit):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.jpg", "test.png", "test.gif"):
             video = PostMedia(image_path(file_name))
             with pytest.raises(ClientException):
-                await subreddit.submit_video("Test Title", video)
+                await subreddit.submit("Test Title", video=video)
 
     async def test_submit_video__invalid_keys(self, reddit):
-        subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
+        message = "'video' contains invalid keys: 'videogif'."
+        subreddit = Subreddit(reddit, display_name="name")
+
         with pytest.raises(TypeError) as excinfo:
-            await subreddit.submit_video(
+            await subreddit.submit(
                 "Cool title",
-                {"media": PostMedia(b"", name="test.mp4"), "videogif": True},
+                video={"media": PostMedia(b"", name="test.mp4"), "videogif": True},
             )
-        assert str(excinfo.value) == "'video' contains invalid keys: 'videogif'."
+        assert str(excinfo.value) == message
 
     async def test_submit_video__invalid_media(self, reddit):
-        subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
+        message = "'media' is required and must be a PostMedia instance."
+        subreddit = Subreddit(reddit, display_name="name")
+
         with pytest.raises(TypeError) as excinfo:
-            await subreddit.submit_video("Cool title", {"gif": True})
-        assert str(excinfo.value) == "'media' is required and must be a PostMedia instance."
+            await subreddit.submit("Cool title", video={"gif": True})
+        assert str(excinfo.value) == message
 
     async def test_upload_banner_additional_image(self, reddit):
         subreddit = Subreddit(reddit, display_name="name")
         with pytest.raises(ValueError):
-            await subreddit.stylesheet.upload_banner_additional_image("dummy_path", align="asdf")
+            await subreddit.stylesheet.upload_banner_additional_image(
+                StylesheetAsset(b"", name="dummy.png"), align="asdf"
+            )
 
 
 class TestSubredditFlair(UnitTest):

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -7,7 +7,7 @@ import pytest
 from aiohttp import ClientResponse
 
 from asyncpraw.exceptions import ClientException, MediaPostFailed
-from asyncpraw.models import InlineGif, InlineImage, InlineVideo, Subreddit, WikiPage
+from asyncpraw.models import InlineGif, InlineImage, InlineVideo, PostMedia, Subreddit, WikiPage
 from asyncpraw.models.reddit.subreddit import SubredditFlairTemplates
 
 from ... import UnitTest
@@ -56,14 +56,12 @@ class TestSubreddit(UnitTest):
         assert hash(subreddit1) != hash(subreddit3)
 
     @mock.patch(
-        "asyncpraw.Reddit.post",
-        new=AsyncMock(return_value={"json": {"data": {"websocket_url": ""}}}),
+        "asyncpraw.models.PostMedia._upload",
+        new=AsyncMock(return_value="fake_media_url"),
     )
     @mock.patch(
-        "asyncpraw.models.Subreddit._upload_media",
-        new=AsyncMock(
-            return_value=("fake_media_url", "fake_websocket_url"),
-        ),
+        "asyncpraw.Reddit.post",
+        new=AsyncMock(return_value={"json": {"data": {"websocket_url": ""}}}),
     )
     @mock.patch("aiohttp.client.ClientSession.ws_connect")
     async def test_invalid_media(self, connection_mock, reddit):
@@ -75,7 +73,7 @@ class TestSubreddit(UnitTest):
         connection_mock.return_value = context_manager
 
         with pytest.raises(MediaPostFailed):
-            await Subreddit(reddit, display_name="test").submit_image("Test", "dummy path")
+            await Subreddit(reddit, display_name="test").submit_image("Test", PostMedia(b"", name="dummy.png"))
         await reddit._core.requestor._http.close()
 
     @mock.patch("aiohttp.client.ClientSession.ws_connect", new=AsyncMock())
@@ -88,17 +86,16 @@ class TestSubreddit(UnitTest):
             },
         ),
     )
-    @mock.patch("asyncpraw.models.Subreddit._read_and_post_media")
+    @mock.patch("asyncpraw.models.PostMedia._post_to_s3")
     async def test_media_upload_500(self, mock_method, reddit):
-        from aiohttp.http_exceptions import HttpProcessingError
         from asyncprawcore.exceptions import ServerError
 
         response = MagicMock(spec=ClientResponse)
-        response.raise_for_status = MagicMock(side_effect=HttpProcessingError(code=500, message=""))
-        response.status = 201
-        mock_method.return_value.__aenter__.return_value = response
+        response.ok = False
+        response.status = 500
+        mock_method.side_effect = ServerError(response=response)
         with pytest.raises(ServerError):
-            await Subreddit(reddit, display_name="test").submit_image("Test", "/dev/null")
+            await Subreddit(reddit, display_name="test").submit_image("Test", PostMedia(b"", name="test.png"))
 
     async def test_notes_delete__invalid_args(self):
         with pytest.raises(TypeError) as excinfo:
@@ -142,9 +139,9 @@ class TestSubreddit(UnitTest):
         # but `inline_media` is not supported for link post selftext
         message = "As of 2025-10-08, `inline_media` is not supported for link post selftext. Only Markdown text can be added to non-self posts."
         subreddit = Subreddit(reddit, display_name="name")
-        gif = InlineGif(caption="optional caption", path="test.gif")
-        image = InlineImage(caption="optional caption", path="test.png")
-        video = InlineVideo(caption="optional caption", path="test.mp4")
+        gif = InlineGif(caption="optional caption", media=PostMedia(b"", name="test.gif"))
+        image = InlineImage(caption="optional caption", media=PostMedia(b"", name="test.png"))
+        video = InlineVideo(caption="optional caption", media=PostMedia(b"", name="test.mp4"))
         selftext = "Text with {gif1}, {image1}, and {video1} inline"
         media = {"gif1": gif, "image1": image, "video1": video}
         with pytest.raises(TypeError) as excinfo:
@@ -153,16 +150,16 @@ class TestSubreddit(UnitTest):
             )
         assert str(excinfo.value) == message
 
-    async def test_submit_gallery__invalid_path(self, reddit):
-        message = "'invalid_image_path' is not a valid image path."
+    async def test_submit_gallery__invalid_media(self, reddit):
+        message = "'media' is required and must be a PostMedia instance."
         subreddit = Subreddit(reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            await subreddit.submit_gallery("Cool title", [{"image_path": "invalid_image_path"}])
+            await subreddit.submit_gallery("Cool title", [{"media": "a string is not PostMedia"}])
         assert str(excinfo.value) == message
 
-    async def test_submit_gallery__missing_path(self, reddit):
-        message = "'image_path' is required."
+    async def test_submit_gallery__missing_media(self, reddit):
+        message = "'media' is required and must be a PostMedia instance."
         subreddit = Subreddit(reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
@@ -178,34 +175,51 @@ class TestSubreddit(UnitTest):
             "yyyyyyyyyyyyyyyy too long caption"
         )
         with pytest.raises(TypeError) as excinfo:
-            await subreddit.submit_gallery("Cool title", [{"image_path": __file__, "caption": caption}])
+            await subreddit.submit_gallery(
+                "Cool title", [{"media": PostMedia(b"", name="test.png"), "caption": caption}]
+            )
         assert str(excinfo.value) == message
 
     async def test_submit_image__bad_filetype(self, image_path, reddit):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.mov", "test.mp4"):
-            image = image_path(file_name)
+            image = PostMedia(image_path(file_name))
             with pytest.raises(ClientException):
                 await subreddit.submit_image("Test Title", image)
 
-    async def test_submit_inline_media__invalid_path(self, reddit):
-        message = "'invalid_image_path' is not a valid file path."
+    async def test_submit_inline_media__invalid_media(self, reddit):
+        message = "'media' must be a PostMedia instance."
         subreddit = Subreddit(reddit, display_name="name")
-        gif = InlineGif(caption="optional caption", path="invalid_image_path")
-        image = InlineImage(caption="optional caption", path="invalid_image_path")
-        video = InlineVideo(caption="optional caption", path="invalid_image_path")
+        gif = InlineGif(caption="optional caption", media="not_post_media")
+        image = InlineImage(caption="optional caption", media="not_post_media")
+        video = InlineVideo(caption="optional caption", media="not_post_media")
         selftext = "Text with {gif1}, {image1}, and {video1} inline"
         media = {"gif1": gif, "image1": image, "video1": video}
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(TypeError) as excinfo:
             await subreddit.submit("title", inline_media=media, selftext=selftext)
         assert str(excinfo.value) == message
 
     async def test_submit_video__bad_filetype(self, image_path, reddit):
         subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.jpg", "test.png", "test.gif"):
-            video = image_path(file_name)
+            video = PostMedia(image_path(file_name))
             with pytest.raises(ClientException):
                 await subreddit.submit_video("Test Title", video)
+
+    async def test_submit_video__invalid_keys(self, reddit):
+        subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
+        with pytest.raises(TypeError) as excinfo:
+            await subreddit.submit_video(
+                "Cool title",
+                {"media": PostMedia(b"", name="test.mp4"), "videogif": True},
+            )
+        assert str(excinfo.value) == "'video' contains invalid keys: 'videogif'."
+
+    async def test_submit_video__invalid_media(self, reddit):
+        subreddit = await reddit.subreddit(pytest.placeholders.test_subreddit)
+        with pytest.raises(TypeError) as excinfo:
+            await subreddit.submit_video("Cool title", {"gif": True})
+        assert str(excinfo.value) == "'media' is required and must be a PostMedia instance."
 
     async def test_upload_banner_additional_image(self, reddit):
         subreddit = Subreddit(reddit, display_name="name")

--- a/tests/unit/models/test_media.py
+++ b/tests/unit/models/test_media.py
@@ -1,0 +1,139 @@
+import pickle
+from pathlib import Path
+
+import pytest
+from asyncprawcore.exceptions import ServerError
+
+from asyncpraw.exceptions import ClientException, TooLargeMediaException
+from asyncpraw.models import EmojiMedia, PostMedia, StylesheetAsset, StylesheetImage, WidgetMedia
+from asyncpraw.models.media import Media
+
+from .. import UnitTest
+
+
+class FakeResponse:
+    """A minimal stand-in for an :class:`aiohttp.ClientResponse`."""
+
+    def __init__(self, text, *, status=400):
+        self._text = text
+        self.status = status
+
+    async def text(self):
+        return self._text
+
+
+class TestMedia(UnitTest):
+    def test_equality(self):
+        media1 = PostMedia(b"data1", name="name1")
+        media2 = PostMedia(b"data1", name="name1")
+        media3 = PostMedia(b"data2", name="name1")
+        media4 = PostMedia(b"data1", name="name2")
+        media5 = EmojiMedia(b"data1", name="name1")
+        assert media1 == media1
+        assert media1 == media2
+        assert media1 != media3
+        assert media1 != media4
+        assert media1 != media5
+
+    def test_hash(self):
+        media1 = PostMedia(b"data1", name="name1")
+        media2 = PostMedia(b"data1", name="name1")
+        media3 = PostMedia(b"data2", name="name2")
+        assert hash(media1) == hash(media2)
+        assert hash(media1) != hash(media3)
+
+    def test_init__bytes(self):
+        media = PostMedia(b"data", name="image.png")
+        assert media.name == "image.png"
+        assert media._fp == b"data"
+
+    def test_init__name_derived_from_path(self, image_path):
+        path = image_path("test.png")
+        media = PostMedia(path)
+        assert media.name == "test.png"
+        assert media._fp == Path(path)
+
+    def test_init__name_overrides_path(self, image_path):
+        media = PostMedia(image_path("test.png"), name="other.png")
+        assert media.name == "other.png"
+
+    def test_init__name_required_for_bytes(self):
+        message = "'name' is required when 'fp' is a bytes object."
+        with pytest.raises(ValueError) as excinfo:
+            PostMedia(b"data")
+        assert str(excinfo.value) == message
+
+    def test_mime_type(self):
+        for name, mime_type in [
+            ("test.gif", "image/gif"),
+            ("test.jpeg", "image/jpeg"),
+            ("test.jpg", "image/jpeg"),
+            ("test.mov", "video/quicktime"),
+            ("test.mp4", "video/mp4"),
+            ("test.png", "image/png"),
+        ]:
+            assert Media(b"data", name=name)._mime_type == mime_type
+
+    def test_mime_type__unknown(self):
+        media = Media(b"data", name="unknown.invalid_extension")
+        message = "Unable to determine the MIME type of 'unknown.invalid_extension'."
+        with pytest.raises(ClientException) as excinfo:
+            media._mime_type
+        assert str(excinfo.value) == message
+
+    def test_pickle(self):
+        media = PostMedia(b"data", name="image.png")
+        for level in range(pickle.HIGHEST_PROTOCOL + 1):
+            other = pickle.loads(pickle.dumps(media, protocol=level))
+            assert media == other
+
+    def test_repr(self):
+        assert repr(PostMedia(b"data", name="image.png")) == "<PostMedia name='image.png'>"
+        assert repr(WidgetMedia(b"data", name="image.jpg")) == "<WidgetMedia name='image.jpg'>"
+
+
+class TestPostMedia(UnitTest):
+    async def test_upload__expected_mime_prefix(self, reddit):
+        media = PostMedia(b"data", name="test.png")
+        message = "Expected a mimetype starting with 'video' but got mimetype 'image/png' (from file name 'test.png')."
+        with pytest.raises(ClientException) as excinfo:
+            await media._upload(reddit, expected_mime_prefix="video")
+        assert str(excinfo.value) == message
+
+    async def test_parse_xml_response__too_large(self):
+        response = FakeResponse(
+            "<Error><Code>EntityTooLarge</Code><Message>Your proposed upload exceeds"
+            " the maximum allowed size</Message><ProposedSize>2000</ProposedSize>"
+            "<MaxSizeAllowed>1000</MaxSizeAllowed></Error>"
+        )
+        with pytest.raises(TooLargeMediaException) as excinfo:
+            await PostMedia._parse_xml_response(response)
+        assert excinfo.value.actual == 2000
+        assert excinfo.value.maximum_size == 1000
+
+    async def test_parse_xml_response__other(self):
+        response = FakeResponse("<Error><Code>AccessDenied</Code><Message>Denied</Message></Error>")
+        assert await PostMedia._parse_xml_response(response) is None
+
+    async def test_raise_upload_error__other(self):
+        response = FakeResponse("<Error><Code>AccessDenied</Code><Message>Denied</Message></Error>")
+        with pytest.raises(ServerError):
+            await PostMedia._raise_upload_error(response)
+
+
+class TestStylesheetAsset(UnitTest):
+    def test_lease_data(self):
+        media = StylesheetAsset(b"data", name="image.png")
+        assert media._build_lease_data(imagetype="bannerBackgroundImage") == {
+            "filepath": "image.png",
+            "mimetype": "image/png",
+            "imagetype": "bannerBackgroundImage",
+        }
+
+
+class TestStylesheetImage(UnitTest):
+    async def test_image_type(self):
+        jpeg = StylesheetImage(b"\xff\xd8\xff data", name="image.jpg")
+        assert (await jpeg._build_payload()).getvalue().startswith(b"\xff\xd8\xff")
+        png = StylesheetImage(b"\x89PNG data", name="image.png")
+        assert (await png._build_payload()).getvalue().startswith(b"\x89PNG")


### PR DESCRIPTION
Stacked on #354.

Mirrors praw's media-upload centralization and the subsequent merge of the per-kind submit methods. Two atomic commits, each independently green.

## 1. Centralize media uploads behind Media classes (`a2c7cf37`)
Adds `asyncpraw/models/media.py` with a `Media` base class and `EmojiMedia`, `PostMedia`, `StylesheetAsset`, `StylesheetImage`, and `WidgetMedia` subclasses (exported from `asyncpraw.models`). Upload methods now take a `Media` instance instead of a path string, and media can be constructed from a path **or** from `bytes` + a `name` (so it no longer has to be written to disk first). Affected: `SubredditEmoji.add`, `SubredditWidgetsModeration.upload_image`, all `SubredditStylesheet.upload*` methods, and the `InlineMedia` subclasses.

Behavioral changes:
- An unknown media type now raises `ClientException` instead of falling back to JPEG.
- S3 uploads go through the requestor, so they respect the configured `timeout` and raise `asyncprawcore` exceptions, consistent with all other requests.

Async notes: files are read lazily with aiofiles at upload time (no blocking I/O in `__init__`), the S3 response is handled via `response.ok`, and the too-large XML error is parsed asynchronously. The scattered inline upload helpers (`_upload_image`, `_upload_style_asset`, `_read_and_post_media`, `_parse_xml_response`) are removed.

## 2. Merge per-kind submit methods into Subreddit.submit (`8f82d081`)
`Subreddit.submit_gallery`, `submit_image`, `submit_poll`, and `submit_video` are merged into a single overloaded `Subreddit.submit`. The kind of submission is selected with the `gallery`, `image`, `poll`, `url`, or `video` keyword argument; these are mutually exclusive, while `selftext` may accompany any of them as optional body text.

```python
from asyncpraw.models import PostMedia

subreddit = await reddit.subreddit("test")
await subreddit.submit("Title", image=PostMedia("image.png"))
await subreddit.submit("Poll", poll={"duration": 3, "options": ["Yes", "No"]})
```

## Verification
ruff + ruff-format clean, pyright 0 errors, strict `-W -n` docs build clean, 100% coverage. Full suite: 1004 passed. Each commit verified independently green (commit 1: 1001 passed in an isolated worktree).