### PR TITLE
Use the Dependencies label for Dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: /
     schedule:
       interval: quarterly
+    labels:
+      - "Dependencies"
   - package-ecosystem: uv
     directory: /
     schedule:
       interval: quarterly
+    labels:
+      - "Dependencies"


### PR DESCRIPTION
Add an explicit `labels:` key to each Dependabot update so its pull requests are labeled with the renamed, Title-cased `Dependencies` label instead of Dependabot's lowercase defaults (`dependencies`, `github_actions`, `python`, `python:uv`), which have been removed for consistency with the rest of the label set.