### PR TITLE
Document that Redditor.overview matches the direct sort methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,7 +41,11 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
   The warning can be silenced by setting the ``PRAW_ALLOW_ENDPOINT_OVERRIDE``
   environment variable.
 - :meth:`.Redditor.overview` to iterate over a Redditor's combined comments and
-  submissions, mirroring the user overview page on Reddit.
+  submissions, mirroring the user overview page on Reddit. It returns the same listing
+  as calling a sort method directly on a :class:`.Redditor`, so
+  ``redditor.overview.new()`` and ``redditor.new()`` yield the same items; use
+  ``redditor.comments`` or ``redditor.submissions`` to restrict the listing to a single
+  type.
 - Add support for Python 3.13.
 - Add support for Python 3.14.
 - Add support for optional Markdown-formatted ``selftext`` when submitting link, image,

--- a/asyncpraw/models/listing/mixins/redditor.py
+++ b/asyncpraw/models/listing/mixins/redditor.py
@@ -43,6 +43,13 @@ class RedditorListingMixin(BaseListingMixin):
         The overview combines a Redditor's comments and submissions, mirroring the user
         overview page on Reddit.
 
+        .. note::
+
+            This is the same listing produced by calling a sort method directly on the
+            :class:`.Redditor` instance, so ``redditor.overview.new()`` and
+            ``redditor.new()`` yield the same items. Use :attr:`.comments` or
+            :attr:`.submissions` to restrict the listing to a single type.
+
         For example, to output the first line of all top items by u/spez try:
 
         .. code-block:: python


### PR DESCRIPTION
Async mirror of praw-dev/praw#2155.

Clarifies that `redditor.overview.new()` and `redditor.new()` return the same listing — the Redditor's combined comments and submissions. A `Redditor` requests the bare `/user/<name>/` endpoint (which Reddit serves as the overview) for its base listing methods, while `overview` requests `/user/<name>/overview` explicitly; both yield the same items. Verified live across four accounts at `limit=1000` (identical order and IDs).

Adds a `.. note::` to the `Redditor.overview` docstring and expands the changelog entry that introduced it. Docs build clean under `-W -n`.