### PR TITLE
Document v8 keyword-only argument change in changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,12 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
 
 **Changed**
 
+- Arguments deprecated for positional use in Async PRAW 7 are now keyword-only across
+  most methods, fulfilling the deprecation announced in 7.6.0. Notably, the
+  ``time_filter`` argument to listing methods such as :meth:`.Subreddit.top` and
+  :meth:`.Subreddit.controversial` — shown positionally in older documentation (for
+  example ``subreddit.top("all")``) — must now be passed by keyword
+  (``subreddit.top(time_filter="all")``).
 - Drop support for Python 3.9, which was end-of-life on 2025-10-31.
 - Require ``asyncprawcore >=3.1.0, <4`` for its public :class:`!Session` and authorizer
   accessors and the widened :meth:`!Session.request` annotations, which let Async PRAW


### PR DESCRIPTION
## Summary

The v8.0.0 changelog never documented that arguments **deprecated for positional use in Async PRAW 7** became **keyword-only in v8**, fulfilling the deprecation announced in 7.6.0.

This gap is most visible with the ``time_filter`` argument to listing methods (``Subreddit.top``, ``Subreddit.controversial``, etc.). Older documentation and examples show it positionally:

```python
subreddit.top("all")
```

Under v8 this now raises:

```
top() takes 1 positional argument but 2 were given
```

and must be passed by keyword instead:

```python
subreddit.top(time_filter="all")
```

## Change

Adds a single leading bullet to the 8.0.0 **Changed** section that states the general change and calls out the notable ``time_filter`` example, placed before the existing specific "must now be passed by keyword" bullets so the general statement leads.

Resolves #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)