### PR TITLE
Add 8.0.2 change log notes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
  Unreleased
 ************
 
+**Changed**
+
+- Reword property docstrings and clarify in the 8.0.0 change log that arguments
+  deprecated for positional use in v7 are now keyword-only. Maintenance and
+  documentation only; no functional changes.
+
 ********************
  8.0.1 (2026/06/15)
 ********************


### PR DESCRIPTION
Adds Unreleased change log notes ahead of the 8.0.2 patch release (documentation/maintenance only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)