### PR TITLE
Enable Dependabot automerge via reusable workflow

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,0 +1,11 @@
+jobs:
+  dependabot_automerge:
+    name: Dependabot automerge
+    permissions:
+      contents: write # required to merge the pull request
+      pull-requests: write # required to enable auto-merge on the pull request
+    uses: praw-dev/.github/.github/workflows/dependabot_automerge.yml@68c4e3402dc6c829ac9a1a787a663baabd21388b # v1.7.0
+name: Dependabot automerge
+on:
+  pull_request:
+permissions: {}


### PR DESCRIPTION
Adds a thin caller for the reusable Dependabot automerge workflow (praw-dev/.github v1.7.0). Non-major Dependabot PRs will auto-merge once required checks pass.