### PR TITLE
Bump pre-commit autoupdate workflow to v1.8.0

### DIFF
--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@ec3a733628adc5bd596def5294dae9fb4eb1e501 # v1.6.0
+    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@34032c07a7e2f432e0bb13ff126ed667d96e2528 # v1.8.0
 name: Update pre-commit hooks
 on:
   schedule:


### PR DESCRIPTION
Bumps the pinned `pre-commit_autoupdate` reusable workflow from v1.6.0 to [v1.8.0](https://github.com/praw-dev/.github/pull/26).

v1.8.0 enables auto-merge on the PR the workflow opens, so pre-commit hook updates merge once the required status checks pass instead of waiting for a manual merge. This repo already has `allow_auto_merge=true`, 0 required approving reviews, and required status checks, so no settings change is needed.