### PR TITLE
Rewind file streams before rate limit retries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@ asyncpraw follows `semantic versioning <https://semver.org/>`_.
  Unreleased
 ************
 
+**Fixed**
+
+- :meth:`.Reddit.post` rewinds seekable file objects before retrying a request after a
+  rate limit response. Previously the retry read from the exhausted stream, which could
+  upload empty or truncated file contents.
+
 ********************
  8.0.2 (2026/06/24)
 ********************

--- a/asyncpraw/reddit.py
+++ b/asyncpraw/reddit.py
@@ -849,14 +849,32 @@ class Reddit:
             provided, ``data`` should not be.
         :param params: The query parameters to add to the request (default: ``None``).
 
+        .. note::
+
+            This method automatically retries after a rate limit response. Only seekable
+            file objects are rewound between attempts; a non-seekable object may be
+            transmitted incompletely if a retry occurs.
+
         """
         if json is None:
             data = data or {}
 
-        attempts = 3
+        file_positions: dict[str, int] = {}
+        if files:
+            for name, file in files.items():
+                try:
+                    position = file.tell()
+                    file.seek(position)
+                except (AttributeError, OSError, ValueError):
+                    continue
+                file_positions[name] = position
+
         last_exception: RedditAPIException | None = None
-        while attempts > 0:
-            attempts -= 1
+        for attempt in range(3):
+            if attempt and file_positions:
+                assert files is not None
+                for name, position in file_positions.items():
+                    files[name].seek(position)
             try:
                 return await self._objectify_request(
                     data=data,

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -1,5 +1,6 @@
 import configparser
 import types
+from io import BytesIO
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
@@ -9,7 +10,7 @@ from asyncprawcore.exceptions import BadRequest
 
 from asyncpraw import Reddit, __version__
 from asyncpraw.config import Config
-from asyncpraw.exceptions import ClientException, RedditAPIException
+from asyncpraw.exceptions import ClientException, RedditAPIException, RedditErrorItem
 from asyncpraw.models import Comment
 
 from . import UnitTest
@@ -182,6 +183,35 @@ class TestReddit(UnitTest):
             await reddit.post("test")
         assert exception.value.items[0].message == "You are doing that too much. Try again in 6 seconds."
         mock_sleep.assert_not_called()
+
+    async def test_post_ratelimit__rewinds_file_streams(self, reddit):
+        upload = BytesIO(b"prefixcomplete file contents")
+        upload.seek(len(b"prefix"))
+        bodies_read = []
+        rate_limit_exception = RedditAPIException([
+            RedditErrorItem(
+                "RATELIMIT",
+                field="ratelimit",
+                message="Try again shortly.",
+            )
+        ])
+
+        async def objectify_request(*, files, **_):
+            body = files["file"].read()
+            bodies_read.append(body)
+            if len(bodies_read) == 1:
+                raise rate_limit_exception
+            return body
+
+        with (
+            mock.patch.object(reddit, "_objectify_request", side_effect=objectify_request),
+            mock.patch.object(reddit, "_handle_rate_limit", return_value=0),
+            mock.patch("asyncio.sleep", return_value=None),
+        ):
+            result = await reddit.post("test", files={"file": upload})
+
+        assert result == b"complete file contents"
+        assert bodies_read == [b"complete file contents", b"complete file contents"]
 
     @mock.patch(
         "asyncpraw.Reddit.request",

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -213,6 +213,49 @@ class TestReddit(UnitTest):
         assert result == b"complete file contents"
         assert bodies_read == [b"complete file contents", b"complete file contents"]
 
+    async def test_post_ratelimit__skips_non_seekable_file_streams(self, reddit):
+        class NonSeekable:
+            def __init__(self):
+                self.seek_calls = 0
+
+            def read(self):
+                return b"contents"
+
+            def seek(self, position):
+                self.seek_calls += 1
+                msg = "underlying stream is not seekable"
+                raise OSError(msg)
+
+            def tell(self):
+                return 0
+
+        upload = NonSeekable()
+        attempts = []
+        rate_limit_exception = RedditAPIException([
+            RedditErrorItem(
+                "RATELIMIT",
+                field="ratelimit",
+                message="Try again shortly.",
+            )
+        ])
+
+        async def objectify_request(*, files, **_):
+            attempts.append(files["file"].read())
+            if len(attempts) == 1:
+                raise rate_limit_exception
+            return attempts[-1]
+
+        with (
+            mock.patch.object(reddit, "_objectify_request", side_effect=objectify_request),
+            mock.patch.object(reddit, "_handle_rate_limit", return_value=0),
+            mock.patch("asyncio.sleep", return_value=None),
+        ):
+            result = await reddit.post("test", files={"file": upload})
+
+        assert result == b"contents"
+        # The probe seek raises, so the object is skipped and never rewound.
+        assert upload.seek_calls == 1
+
     @mock.patch(
         "asyncpraw.Reddit.request",
         new=AsyncMock(


### PR DESCRIPTION
Ports the fix from praw-dev/praw#2179 (issue praw-dev/praw#2178) to Async PRAW, which has the identical retry loop and the same bug.

`Reddit.post` retries up to three times after a retryable RATELIMIT response, passing the same `files` mapping each time. Transmitting a multipart body advances each file object's position, so the retry read from the exhausted stream and uploaded empty or truncated contents — silently, since no error is raised.

## Changes

- Record the starting position of each seekable file object before the first attempt, and restore those positions before each retry.
- Leave non-seekable objects alone, and note in the `post` docstring that only seekable file objects are rewound between retries.
- Add a regression test using a `BytesIO` that starts at a non-zero offset, so a naive `seek(0)` would not pass it.
- Add a `CHANGES.rst` entry.

The seekability probe calls `tell()` and then seeks back to that same position, so objects where `tell` works but `seek` does not are skipped rather than raising.

## Tests

Verified the new test fails without the fix (the retry reads `b''`) and passes with it.

```
uv run pytest tests/unit -q
353 passed
```