### PR TITLE
Run Dependabot daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: daily
     labels:
       - "Dependencies"
     cooldown:
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: uv
     directory: /
     schedule:
-      interval: monthly
+      interval: daily
     labels:
       - "Dependencies"
     cooldown:


### PR DESCRIPTION
Now that non-major Dependabot updates auto-merge (see the v1.9.0 caller bump), there is no reason to batch them monthly. `daily` is the most frequent interval Dependabot supports for version updates.

- `schedule.interval`: `monthly` -> `daily` for every ecosystem.

Grouping and the existing `cooldown.default-days: 1` are unchanged, so this still produces at most one PR per ecosystem per day, and only once a release is a day old. Major bumps continue to land as manual-review PRs.