### PR TITLE
Collapse the github-actions Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,14 +12,6 @@ updates:
       github-actions:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
-      github-actions-major:
-        patterns:
-          - "*"
-        update-types:
-          - "major"
   - package-ecosystem: uv
     directory: /
     schedule:


### PR DESCRIPTION
Collapses the `github-actions` semver split back into a single group, now that [.github v1.10.0](https://github.com/praw-dev/.github/pull/35) auto-merges major action bumps.

The split existed so one major would not block the non-major updates grouped with it. With action majors auto-merging, `github-actions-major` only produced a second PR that merged anyway, so a single group means one PR per day instead of two.

The `python` split is unchanged: python majors still group separately and still stop for manual review.